### PR TITLE
breaking: decouple parser switch and transformer switch

### DIFF
--- a/rewrite-pattern.js
+++ b/rewrite-pattern.js
@@ -202,11 +202,13 @@ const processTerm = (item, regenerateOptions, groups) => {
 			item = processCharacterClass(item, regenerateOptions);
 			break;
 		case 'unicodePropertyEscape':
-			update(
-				item,
-				getUnicodePropertyEscapeSet(item.value, item.negative)
-					.toString(regenerateOptions)
-			);
+			if (config.unicodePropertyEscape) {
+				update(
+					item,
+					getUnicodePropertyEscapeSet(item.value, item.negative)
+						.toString(regenerateOptions)
+				);
+			}
 			break;
 		case 'characterClassEscape':
 			update(
@@ -222,7 +224,7 @@ const processTerm = (item, regenerateOptions, groups) => {
 			if (item.behavior == 'normal') {
 				groups.lastIndex++;
 			}
-			if (item.name) {
+			if (item.name && config.namedGroup) {
 				const name = item.name.value;
 
 				if (groups.names[name]) {
@@ -299,19 +301,23 @@ const config = {
 	'ignoreCase': false,
 	'unicode': false,
 	'dotAll': false,
-	'useUnicodeFlag': false
+	'useUnicodeFlag': false,
+	'unicodePropertyEscape': false,
+	'namedGroup': false
 };
 const rewritePattern = (pattern, flags, options) => {
+	config.unicode = flags && flags.includes('u');
 	const regjsparserFeatures = {
-		'unicodePropertyEscape': options && options.unicodePropertyEscape,
-		'namedGroups': options && options.namedGroup,
-		'lookbehind': options && options.lookbehind
+		'unicodePropertyEscape': config.unicode,
+		'namedGroups': true,
+		'lookbehind': true
 	};
 	config.ignoreCase = flags && flags.includes('i');
-	config.unicode = flags && flags.includes('u');
 	const supportDotAllFlag = options && options.dotAllFlag;
 	config.dotAll = supportDotAllFlag && flags && flags.includes('s');
+	config.namedGroup = options && options.namedGroup;
 	config.useUnicodeFlag = options && options.useUnicodeFlag;
+	config.unicodePropertyEscape = options && options.unicodePropertyEscape;
 	const regenerateOptions = {
 		'hasUnicodeFlag': config.useUnicodeFlag,
 		'bmpOnly': !config.unicode

--- a/rewrite-pattern.js
+++ b/rewrite-pattern.js
@@ -310,7 +310,7 @@ const rewritePattern = (pattern, flags, options) => {
 	const regjsparserFeatures = {
 		'unicodePropertyEscape': config.unicode,
 		'namedGroups': true,
-		'lookbehind': true
+		'lookbehind': options && options.lookbehind
 	};
 	config.ignoreCase = flags && flags.includes('i');
 	const supportDotAllFlag = options && options.dotAllFlag;

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -583,14 +583,6 @@ describe('unicodePropertyEscapes', () => {
 			rewritePattern('\\P{ASCII_Hex_Digit}', '', features);
 		}, Error);
 	});
-	it('throws without the `unicodePropertyEscape` feature enabled', () => {
-		assert.throws(() => {
-			rewritePattern('\\p{ASCII_Hex_Digit}', 'u');
-		}, Error);
-		assert.throws(() => {
-			rewritePattern('\\P{ASCII_Hex_Digit}', 'u');
-		}, Error);
-	});
 	it('throws on unknown binary properties', () => {
 		assert.throws(() => {
 			rewritePattern('\\p{UnknownBinaryProperty}', 'u', features);
@@ -687,6 +679,12 @@ describe('unicodePropertyEscapes', () => {
 				'useUnicodeFlag': true
 			}),
 			'[\\u{14400}-\\u{14646}]'
+		);
+	});
+	it('should not transpile unicode property when unicodePropertyEscape is not enabled', () => {
+		assert.equal(
+			rewritePattern('\\p{ASCII_Hex_Digit}\\P{ASCII_Hex_Digit}', 'u'),
+			'\\p{ASCII_Hex_Digit}\\P{ASCII_Hex_Digit}'
 		);
 	});
 	assert.equal(
@@ -829,7 +827,6 @@ describe('namedGroup', () => {
 
 	it('onNamedGroup is optional', () => {
 		let transpiled;
-		const pattern = '(?<name>)';
 		const expected = '()';
 		assert.doesNotThrow(() => {
 			transpiled = rewritePattern('(?<name>)', '', {
@@ -854,6 +851,15 @@ describe('namedGroup', () => {
 			});
 		});
 	});
+
+	it('should not transpile when namedGroup is not enabled', () => {
+		let transpiled;
+		const expected = '(?<name>)';
+		assert.doesNotThrow(() => {
+			transpiled = rewritePattern('(?<name>)', '');
+		});
+		assert.strictEqual(expected, transpiled);
+	})
 });
 
 const lookbehindFixtures = [


### PR DESCRIPTION
In this PR we decouple the regjsparser switch from the regexpu-core transformer switch. It is a breaking change since it does not throw for `\\p{Unified_Ideograph}` when `unicodePropertyEscape` is not enabled, instead it assumes our user know exactly what she is doing and only transform the features as instructed.

By doing this, `babel-preset-env` can have more granular control on ES6+ regex features. For example, when user specifies
```json
{
  "target": "Hypothetical browser supports unicode property escape but not named capturing groups"
}
```
and let's say the pattern we want to transform is `/(?<name>\p{Unified_Ideograph}{3})/u` we don't have to transform unicode property escape here and instead should only pass `namedGroup: true`. 
```js
rewritePattern(
  /(?<name>\p{Unified_Ideograph}{3})/u,
  "u",
  { namedGroup: true }
)
// expect to transform `?<name>` only without touching `\p{Unified_Ideograph}`
```

However, to transform this pattern, we still need regjsparser support for unicode property escape otherwise the parser will throw on `\p{`. Therefore, we maximize the parser support, allow parser to parse any new syntax, and only transform when user opt-in the transformation. By doing so we encourage to ship native browser features without superfluous transformations.

Edits: the previous `Safari 12` example above is practically invalid as of Sep 2019. Every browser supports unicode property escape also support named capturing groups.