### PR TITLE
fix: skip ascii symbol in process

### DIFF
--- a/rewrite-pattern.js
+++ b/rewrite-pattern.js
@@ -677,6 +677,10 @@ const processTerm = (item, regenerateOptions, groups) => {
 			break;
 		case 'value':
 			const codePoint = item.codePoint;
+			if (item.kind === "symbol" && codePoint < 0x80) {
+				// skip regenerate when it is an ASCII symbol
+				break;
+			}
 			const set = regenerate(codePoint);
 			const folded = maybeFold(codePoint);
 			set.add(folded);

--- a/rewrite-pattern.js
+++ b/rewrite-pattern.js
@@ -677,8 +677,8 @@ const processTerm = (item, regenerateOptions, groups) => {
 			break;
 		case 'value':
 			const codePoint = item.codePoint;
-			if (item.kind === "symbol" && codePoint < 0x80) {
-				// skip regenerate when it is an ASCII symbol
+			if (item.kind === "symbol" && codePoint >= 0x20 && codePoint <= 0x7E) {
+				// skip regenerate when it is a printable ASCII symbol
 				break;
 			}
 			const set = regenerate(codePoint);

--- a/rewrite-pattern.js
+++ b/rewrite-pattern.js
@@ -677,12 +677,12 @@ const processTerm = (item, regenerateOptions, groups) => {
 			break;
 		case 'value':
 			const codePoint = item.codePoint;
-			if (item.kind === "symbol" && codePoint >= 0x20 && codePoint <= 0x7E) {
+			const set = regenerate(codePoint);
+			const folded = maybeFold(codePoint);
+			if (folded.length === 1 && item.kind === "symbol" && folded[0] >= 0x20 && folded[0] <= 0x7E) {
 				// skip regenerate when it is a printable ASCII symbol
 				break;
 			}
-			const set = regenerate(codePoint);
-			const folded = maybeFold(codePoint);
 			set.add(folded);
 			update(item, set.toString(regenerateOptions));
 			break;

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -737,6 +737,12 @@ describe('unicodePropertyEscapes', () => {
 			'\\u03B8'
 		);
 	});
+	it('should not replace `-` symbol when not in character class range', () => {
+		assert.equal(
+			rewritePattern('-'),
+			'-'
+		)
+	})
 });
 
 const dotAllFlagFixtures = [


### PR DESCRIPTION
In this PR we skip the `processItem` when it is a `symbol`-kind and has code point within ASCII range.

This fix will prevent `-` transpiled as `\\x2D` when it is not in character class. Besides that, it should speed up a little bit since ASCII symbols are pretty common.