### PR TITLE
support useDotAllFlag

### DIFF
--- a/rewrite-pattern.js
+++ b/rewrite-pattern.js
@@ -323,7 +323,7 @@ const rewritePattern = (pattern, flags, options) => {
 	config.useUnicodeFlag = options && options.useUnicodeFlag;
 	config.unicodePropertyEscape = options && options.unicodePropertyEscape;
 	if (supportDotAllFlag && config.useDotAllFlag) {
-		throw new Error("`useDotAllFlag` and `dotAllFlag` could not be both true!")
+		throw new Error('`useDotAllFlag` and `dotAllFlag` cannot both be true!');
 	}
 	const regenerateOptions = {
 		'hasUnicodeFlag': config.useUnicodeFlag,

--- a/rewrite-pattern.js
+++ b/rewrite-pattern.js
@@ -188,7 +188,9 @@ const assertNoUnmatchedReferences = (groups) => {
 const processTerm = (item, regenerateOptions, groups) => {
 	switch (item.type) {
 		case 'dot':
-			if (config.unicode) {
+			if (config.useDotAllFlag) {
+				break;
+			} else if (config.unicode) {
 				update(
 					item,
 					getUnicodeDotSet(config.dotAll).toString(regenerateOptions)
@@ -301,6 +303,7 @@ const config = {
 	'ignoreCase': false,
 	'unicode': false,
 	'dotAll': false,
+	'useDotAllFlag': false,
 	'useUnicodeFlag': false,
 	'unicodePropertyEscape': false,
 	'namedGroup': false
@@ -316,8 +319,12 @@ const rewritePattern = (pattern, flags, options) => {
 	const supportDotAllFlag = options && options.dotAllFlag;
 	config.dotAll = supportDotAllFlag && flags && flags.includes('s');
 	config.namedGroup = options && options.namedGroup;
+	config.useDotAllFlag = options && options.useDotAllFlag;
 	config.useUnicodeFlag = options && options.useUnicodeFlag;
 	config.unicodePropertyEscape = options && options.unicodePropertyEscape;
+	if (supportDotAllFlag && config.useDotAllFlag) {
+		throw new Error("`useDotAllFlag` and `dotAllFlag` could not be both true!")
+	}
 	const regenerateOptions = {
 		'hasUnicodeFlag': config.useUnicodeFlag,
 		'bmpOnly': !config.unicode

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -739,6 +739,39 @@ describe('dotAllFlag', () => {
 	}
 });
 
+const useDotAllFlagFixtures = [
+	{
+		'pattern': '.',
+		'flags': 'su',
+		'expected': '.'
+	}
+]
+
+describe('useDotAllFlag', () => {
+	const features = {
+		'useDotAllFlag': true
+	};
+	for (const fixture of useDotAllFlagFixtures) {
+		const pattern = fixture.pattern;
+		const flags = fixture.flags;
+		it('rewrites `/' + pattern + '/' + flags + '` correctly', () => {
+			const transpiled = rewritePattern(pattern, flags, features);
+			const expected = fixture.expected;
+			if (transpiled != '(?:' + expected + ')') {
+				assert.strictEqual(transpiled, expected);
+			}
+		});
+	}
+	it('should throw when both `useDotAllFlag` and `dotAll` is true', () => {
+		assert.throws(() => {
+			rewritePattern(".", "s", {
+				useDotAllFlag: true,
+				dotAllFlag: true
+			});
+		}, Error, "`useDotAllFlag` and `dotAllFlag` could not be both true!")
+	})
+})
+
 const namedGroupFixtures = [
 	{
 		'pattern': '(?<name>)\\k<name>',

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -764,11 +764,11 @@ describe('useDotAllFlag', () => {
 	}
 	it('should throw when both `useDotAllFlag` and `dotAll` is true', () => {
 		assert.throws(() => {
-			rewritePattern(".", "s", {
+			rewritePattern('.', 's', {
 				useDotAllFlag: true,
 				dotAllFlag: true
 			});
-		}, Error, "`useDotAllFlag` and `dotAllFlag` could not be both true!")
+		}, Error, '`useDotAllFlag` and `dotAllFlag` cannot both be true!')
 	})
 })
 


### PR DESCRIPTION
In this PR we introduce `useDotAllFlag` to instruct that the `/s` flag is used in the transpiled result, which mean `dot` can skip transpilation when `useDotAllFlag: true` is specified.

The typical use case is that the user would like to preserve `/s` flag while transforming the other features:
```js
rewritePattern('<(?<tag>\d)+>.*?<\/\k<tag>>', 'su', {
  'namedGroup': true
})
// returns (incorrect due to dotAll is not respected)
// <([0-9])+>[\0-\t\x0B\f\x0E-\u{2027}\u{202A}-\u{10FFFF}]*?<\/\1>

rewritePattern('<(?<tag>\d)+>.*?<\/\k<tag>>', 'su', {
  'namedGroup': true,
  'dotAllFlag': true,
})

// returns (correct but suboptimal)
// <([0-9])+>[\0-\u{10FFFF}]*?<\/\1>

rewritePattern('<(?<tag>\d)+>.*?<\/\k<tag>>', 'su', {
  'namedGroup': true,
  'useDotAllFlag': true,
})

// expected (the dot transform is skipped)
// <([0-9])+>.*?<\/\1>

```

If we agree on the API design, I would add docs to `README.md`.