### PR TITLE
fix: allow keep named group names when namedGroup is true

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Setting this option to `true` enables support for [named capture groups](https:/
 
 ```js
 rewritePattern('(?<name>.)\k<name>', '', {
-  'namedGroups': true
+  'namedGroup': true
 });
 // → '(.)\1'
 ```
@@ -115,7 +115,7 @@ the name of the group, and its index.
 
 ```js
 rewritePattern('(?<name>.)\k<name>', '', {
-  'namedGroups': true,
+  'namedGroup': true,
   onNamedGroup(name, index) {
     console.log(name, index);
     // → 'name', 1

--- a/demo.js
+++ b/demo.js
@@ -16,3 +16,11 @@ console.log(processedPattern);
 
 // throws
 new RegExp(processedPattern, 'u');
+
+console.log(rewritePattern('(?<name>.)\\k<name>', '', {
+	'namedGroup': true
+}))
+
+console.log(rewritePattern('(?<name>.)\\k<name>', '', {
+	'namedGroup': false
+}))

--- a/rewrite-pattern.js
+++ b/rewrite-pattern.js
@@ -174,6 +174,9 @@ const processCharacterClass = (characterClassItem, regenerateOptions) => {
 };
 
 const updateNamedReference = (item, index) => {
+	if (config.namedGroup) {
+		return;
+	}
 	delete item.name;
 	item.matchIndex = index;
 };
@@ -224,7 +227,7 @@ const processTerm = (item, regenerateOptions, groups) => {
 			if (item.behavior == 'normal') {
 				groups.lastIndex++;
 			}
-			if (item.name && config.namedGroup) {
+			if (item.name) {
 				const name = item.name.value;
 
 				if (groups.names[name]) {
@@ -234,7 +237,9 @@ const processTerm = (item, regenerateOptions, groups) => {
 				}
 
 				const index = groups.lastIndex;
-				delete item.name;
+				if (!config.namedGroup) {
+					delete item.name;
+				}
 
 				groups.names[name] = index;
 				if (groups.onNamedGroup) {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -819,7 +819,6 @@ describe('namedGroup', () => {
 		const groups = [];
 
 		Object.assign(options, {
-			'namedGroup': true,
 			'onNamedGroup': (name, index) => {
 				groups.push([ name, index ]);
 			}
@@ -832,15 +831,32 @@ describe('namedGroup', () => {
 				assert.deepStrictEqual(groups, expectedGroups);
 			}
 		});
+
+		it('should not transpile `/' + pattern + '/' + flags + '` correctly', () => {
+
+			const groups = [];
+
+			Object.assign(options, {
+				'namedGroup': true,
+				'onNamedGroup': (name, index) => {
+					groups.push([ name, index ]);
+				}
+			});
+
+			const transpiled = rewritePattern(pattern, flags, options);
+			assert.strictEqual(transpiled, pattern);
+			if (expectedGroups) {
+				assert.deepStrictEqual(groups, expectedGroups);
+			}
+		});
+
 	}
 
 	it('onNamedGroup is optional', () => {
 		let transpiled;
 		const expected = '()';
 		assert.doesNotThrow(() => {
-			transpiled = rewritePattern('(?<name>)', '', {
-				'namedGroup': true
-			});
+			transpiled = rewritePattern('(?<name>)', '');
 		});
 		assert.strictEqual(transpiled, expected);
 	});
@@ -861,14 +877,26 @@ describe('namedGroup', () => {
 		});
 	});
 
-	it('should not transpile when namedGroup is not enabled', () => {
+	it('should transpile when namedGroup is not enabled', () => {
 		let transpiled;
-		const expected = '(?<name>)';
+		const expected = '()';
 		assert.doesNotThrow(() => {
 			transpiled = rewritePattern('(?<name>)', '');
 		});
 		assert.strictEqual(expected, transpiled);
 	})
+
+	it('should not transpile when namedGroup is enabled', () => {
+		let transpiled;
+		const expected = '(?<name>)';
+		assert.doesNotThrow(() => {
+			transpiled = rewritePattern('(?<name>)', '', {
+				'namedGroup': true
+			});
+		});
+		assert.strictEqual(expected, transpiled);
+	})
+
 });
 
 const lookbehindFixtures = [


### PR DESCRIPTION
https://github.com/mathiasbynens/regexpu-core/issues/37

BREAKING CHANGE:

- not transpile when namedGroup is enabled
- transpile when namedGroup is not enabled