### PR TITLE
Implement negative character classes with a negative lookahead

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
 		"jsesc": "^2.5.2",
 		"lodash": "^4.17.15",
 		"mocha": "^7.1.0",
-		"regexpu-fixtures": "2.1.3",
+		"regexpu-fixtures": "2.1.4",
 		"unicode-13.0.0": "^0.8.0"
 	}
 }

--- a/rewrite-pattern.js
+++ b/rewrite-pattern.js
@@ -129,7 +129,7 @@ const caseFold = (codePoint) => {
 };
 
 const processCharacterClass = (characterClassItem, regenerateOptions) => {
-	let set = regenerate();
+	const set = regenerate();
 	for (const item of characterClassItem.body) {
 		switch (item.type) {
 			case 'value':
@@ -167,9 +167,10 @@ const processCharacterClass = (characterClassItem, regenerateOptions) => {
 		}
 	}
 	if (characterClassItem.negative) {
-		set = (config.unicode ? UNICODE_SET : BMP_SET).clone().remove(set);
+		update(characterClassItem, `(?!${set.toString(regenerateOptions)})[\\s\\S]`)
+	} else {
+		update(characterClassItem, set.toString(regenerateOptions));
 	}
-	update(characterClassItem, set.toString(regenerateOptions));
 	return characterClassItem;
 };
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -560,6 +560,10 @@ describe('unicodePropertyEscapes', () => {
 			'[0-9A-F_a-f]'
 		);
 		assert.equal(
+			rewritePattern('[^\\p{ASCII_Hex_Digit}_]', 'u', features),
+			'(?:(?![0-9A-F_a-f])[\\s\\S])'
+		);
+		assert.equal(
 			rewritePattern('[\\P{Script_Extensions=Anatolian_Hieroglyphs}]', 'u', features),
 			'(?:[\\0-\\uD7FF\\uE000-\\uFFFF]|[\\uD800-\\uD810\\uD812-\\uDBFF][\\uDC00-\\uDFFF]|\\uD811[\\uDE47-\\uDFFF]|[\\uD800-\\uDBFF](?![\\uDC00-\\uDFFF])|(?:[^\\uD800-\\uDBFF]|^)[\\uDC00-\\uDFFF])'
 		);
@@ -696,16 +700,18 @@ describe('unicodePropertyEscapes', () => {
 			'\\p{ASCII_Hex_Digit}\\P{ASCII_Hex_Digit}'
 		);
 	});
-	assert.equal(
-		rewritePattern('\u03B8', 'iu'),
-		'[\\u03B8\\u03F4]'
-	);
-	assert.equal(
-		rewritePattern('\u03B8', 'iu', {
-			'useUnicodeFlag': true
-		}),
-		'\\u03B8'
-	);
+	it('should transpile to minimal case-insensitive set', () => {
+		assert.equal(
+			rewritePattern('\u03B8', 'iu'),
+			'[\\u03B8\\u03F4]'
+		);
+		assert.equal(
+			rewritePattern('\u03B8', 'iu', {
+				'useUnicodeFlag': true
+			}),
+			'\\u03B8'
+		);
+	});
 });
 
 const dotAllFlagFixtures = [
@@ -931,3 +937,97 @@ describe('lookbehind', () => {
 		});
 	}
 })
+
+const characterClassFixtures = [
+	{
+		pattern: '[^K]', // LATIN CAPITAL LETTER K
+		flags: 'iu',
+		expected: '(?![K\\u212A])[\\s\\S]'
+	},
+	{
+		pattern: '[^k]', // LATIN SMALL LETTER K
+		flags: 'iu',
+		expected: '(?![k\\u212A])[\\s\\S]'
+	},
+	{
+		pattern: '[^\u212a]', // KELVIN SIGN
+		flags: 'iu',
+		expected: '(?![K\\u212A])[\\s\\S]'
+	},
+	{
+		pattern: '[^K]', // LATIN CAPITAL LETTER K
+		flags: 'iu',
+		expected: '(?!K)[\\s\\S]',
+		useUnicodeFlag: true
+	},
+	{
+		pattern: '[^k]', // LATIN SMALL LETTER K
+		flags: 'iu',
+		expected: '(?!k)[\\s\\S]',
+		useUnicodeFlag: true
+	},
+	{
+		pattern: '[^\u212a]', // KELVIN SIGN
+		flags: 'iu',
+		expected: '(?!\\u212A)[\\s\\S]',
+		useUnicodeFlag: true
+	},
+	{
+		pattern: '[^K]', // LATIN CAPITAL LETTER K
+		flags: 'u',
+		expected: '(?!K)[\\s\\S]'
+	},
+	{
+		pattern: '[^k]', // LATIN SMALL LETTER K
+		flags: 'u',
+		expected: '(?!k)[\\s\\S]'
+	},
+	{
+		pattern: '[^\u212a]', // KELVIN SIGN
+		flags: 'u',
+		expected: '(?!\\u212A)[\\s\\S]'
+	},
+	{
+		pattern: '[^K]', // LATIN CAPITAL LETTER K
+		flags: 'u',
+		expected: '(?!K)[\\s\\S]',
+		useUnicodeFlag: true
+	},
+	{
+		pattern: '[^k]', // LATIN SMALL LETTER K
+		flags: 'u',
+		expected: '(?!k)[\\s\\S]',
+		useUnicodeFlag: true
+	},
+	{
+		pattern: '[^\u212a]', // KELVIN SIGN
+		flags: 'u',
+		expected: '(?!\\u212A)[\\s\\S]',
+		useUnicodeFlag: true
+	},
+	{
+		pattern: '[^\u212a]', // KELVIN SIGN
+		flags: 'u',
+		expected: '(?!\\u212A)[\\s\\S]',
+		useUnicodeFlag: true
+	},
+];
+
+describe('character classes', () => {
+	for (const fixture of characterClassFixtures) {
+		const pattern = fixture.pattern;
+		const flags = fixture.flags;
+		const useUnicodeFlag = fixture.useUnicodeFlag;
+		it('rewrites `/' + pattern + '/' + flags + '` with' + (useUnicodeFlag ? '' : 'out') + ' unicode correctly', () => {
+			const transpiled = rewritePattern(pattern, flags, {
+				'useUnicodeFlag': useUnicodeFlag
+			});
+			const expected = fixture.expected;
+			const features = fixture.features;
+			if (transpiled != '(?:' + expected + ')') {
+				assert.strictEqual(transpiled, expected);
+			}
+		});
+	}
+});
+

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1004,13 +1004,7 @@ const characterClassFixtures = [
 		flags: 'u',
 		expected: '(?!\\u212A)[\\s\\S]',
 		useUnicodeFlag: true
-	},
-	{
-		pattern: '[^\u212a]', // KELVIN SIGN
-		flags: 'u',
-		expected: '(?!\\u212A)[\\s\\S]',
-		useUnicodeFlag: true
-	},
+	}
 ];
 
 describe('character classes', () => {


### PR DESCRIPTION
This allows us to take advantage of the browser's natrual case folding for `i` flag.

Fixes #45