### PR TITLE
Implement support for `&&` and `||` in `v` sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,15 +114,38 @@ These options can be set to `false` or `'transform'`. When using `'transform'`, 
   // → '(.)\1'
   ```
 
-<!--
-
 #### Experimental regular expression features
 
 These options can be set to `false`, `'parse'` and `'transform'`. When using `'transform'`, the corresponding features are compiled to older syntax that can run in older browsers. When using `'parse'`, they are parsed and left as-is in the output pattern. When using `false` (the default), they result in a syntax error if used.
 
-NOTE: Currently regexpu doesn't support any ECMAScript proposal
+Once these features become stable (when the proposals are accepted as part of ECMAScript), they will be parsed by default and thus `'parse'` will behave like `false`.
 
--->
+- `unicodeSetsFlag` - [The `v` (`unicodeSets`) flag](https://github.com/tc39/proposal-regexp-set-notation)
+
+  ```js
+  rewritePattern('[\\p{Emoji}&&\\p{ASCII}]', 'u', {
+    unicodeSetsFlag: 'transform'
+  });
+  // → '[#\*0-9]'
+  ```
+
+  By default, patterns with the `v` flag are transformed to patterns with the `u` flag. If you want to downlevel them more you can set the `unicodeFlag: 'transform'` option.
+
+  ```js
+  rewritePattern('[^[a-h]&&[f-z]]', 'v', {
+    unicodeSetsFlag: 'transform'
+  });
+  // → '[^f-h]' (to be used with /u)
+  ```
+
+  ```js
+  rewritePattern('[^[a-h]&&[f-z]]', 'v', {
+    unicodeSetsFlag: 'transform',
+    unicodeFlag: 'transform'
+  });
+  // → '(?:(?![f-h])[\s\S])' (to be used without /u)
+  ```
+
 
 #### Miscellaneous options
 

--- a/demo.js
+++ b/demo.js
@@ -5,15 +5,11 @@ const parse = require('regjsparser').parse;
 const generate = require('regjsgen').generate;
 const regenerate = require('regenerate');
 
-const pattern = String.raw`\w`;
+const pattern = String.raw`[[a-h]&&[f-z]]`;
 
-console.log(generate(parse(pattern)));
-
-const processedPattern = rewritePattern(pattern, 'ui', {
-	'unicodeFlag': 'transform'
+const processedPattern = rewritePattern(pattern, 'v', {
+	'unicodeSetFlag': 'transform'
 });
 
 console.log(processedPattern);
 
-// throws
-new RegExp(processedPattern, 'u');

--- a/demo.js
+++ b/demo.js
@@ -8,7 +8,7 @@ const regenerate = require('regenerate');
 const pattern = String.raw`[[a-h]&&[f-z]]`;
 
 const processedPattern = rewritePattern(pattern, 'v', {
-	'unicodeSetFlag': 'transform'
+	'unicodeSetsFlag': 'transform'
 });
 
 console.log(processedPattern);

--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
 	"dependencies": {
 		"regenerate": "^1.4.2",
 		"regenerate-unicode-properties": "^9.0.0",
-		"regjsgen": "^0.5.2",
-		"regjsparser": "^0.7.0",
+		"regjsgen": "^0.6.0",
+		"regjsparser": "^0.8.2",
 		"unicode-match-property-ecmascript": "^2.0.0",
 		"unicode-match-property-value-ecmascript": "^2.0.0"
 	},

--- a/rewrite-pattern.js
+++ b/rewrite-pattern.js
@@ -11,9 +11,6 @@ const ESCAPE_SETS = require('./data/character-class-escape-sets.js');
 // Prepare a Regenerate set containing all code points, used for negative
 // character classes (if any).
 const UNICODE_SET = regenerate().addRange(0x0, 0x10FFFF);
-// Without the `u` flag, the range stops at 0xFFFF.
-// https://mths.be/es6#sec-pattern-semantics
-const BMP_SET = regenerate().addRange(0x0, 0xFFFF);
 
 // Prepare a Regenerate set containing all code points that are supposed to be
 // matched by `/./u`. https://mths.be/es6#sec-atom
@@ -98,6 +95,16 @@ regenerate.prototype.iuAddRange = function(min, max) {
 	} while (++min <= max);
 	return $this;
 };
+regenerate.prototype.iuRemoveRange = function(min, max) {
+	const $this = this;
+	do {
+		const folded = caseFold(min);
+		if (folded) {
+			$this.remove(folded);
+		}
+	} while (++min <= max);
+	return $this;
+};
 
 const update = (item, pattern) => {
 	let tree = parse(pattern, config.useUnicodeFlag ? 'u' : '');
@@ -128,41 +135,117 @@ const caseFold = (codePoint) => {
 	return iuMappings.get(codePoint) || false;
 };
 
-const processCharacterClass = (characterClassItem, regenerateOptions) => {
+const buildHandler = (action) => {
+	switch (action) {
+		case 'union':
+			return {
+				single: (set, cp) => set ? set.add(cp) : regenerate(cp),
+				regSet: (set, set2) => set ? set.add(set2) : set2,
+				range: (set, start, end) => {
+					if (!set) set = regenerate();
+					set.addRange(start, end);
+					return set;
+				},
+				iuRange: (set, start, end) => {
+					if (!set) set = regenerate();
+					set.iuAddRange(start, end);
+					return set;
+				}
+			};
+		case 'union-negative':
+			return {
+				single: (set, cp) => set && set.contains(cp) ? UNICODE_SET.clone() : UNICODE_SET.clone().remove(cp),
+				regSet: (set, set2) => UNICODE_SET.clone().remove(set2).add(set || []),
+				range: (set, start, end) => UNICODE_SET.clone().removeRange(start, end).add(set || []),
+				iuRange: (set, start, end) => UNICODE_SET.clone().iuRemoveRange(start, end).add(set || [])
+			};
+		case 'intersection':
+			const regSet = (set, set2) => set ? set.intersection(set2) : set2;
+			return {
+				single: (set, cp) => !set || set.contains(cp) ? regenerate(cp) : regenerate(),
+				regSet: regSet,
+				range: (set, start, end) => regSet(set, regenerate().addRange(start, end)),
+				iuRange: (set, start, end) => regSet(set, regenerate().iuAddRange(start, end))
+			};
+		case 'subtraction':
+			return {
+				single: (set, cp) => set ? set.remove(cp) : regenerate(cp),
+				regSet: (set, set2) => set ? set.remove(set2) : set2,
+				range: (set, start, end) => set ? set.removeRange(start, end) : regenerate().addRange(start, end),
+				iuRange: (set, start, end) => set ? set.iuRemoveRange(start, end) : regenerate().iuAddRange(start, end)
+			};
+		// The `default` clause is only here as a safeguard; it should never be
+		// reached. Code coverage tools should ignore it.
+		/* istanbul ignore next */
+		default:
+			throw new Error(`Unknown set action: ${ characterClassItem.kind }`);
+	}
+};
+
+const computeCharacterClass = (characterClassItem) => {
 	let transformed = config.transform.unicodeFlag;
-	const negative = characterClassItem.negative;
-	const set = regenerate();
+	let set;
+
+	let handlePositive;
+	let handleNegative;
+
+	switch (characterClassItem.kind) {
+		case 'union':
+			handlePositive = buildHandler('union');
+			handleNegative = buildHandler('union-negative');
+			break;
+		case 'intersection':
+			handlePositive = buildHandler('intersection');
+			handleNegative = buildHandler('subtraction');
+			break;
+		case 'subtraction':
+			handlePositive = buildHandler('subtraction');
+			handleNegative = buildHandler('intersection');
+			break;
+		// The `default` clause is only here as a safeguard; it should never be
+		// reached. Code coverage tools should ignore it.
+		/* istanbul ignore next */
+		default:
+			throw new Error(`Unknown character class kind: ${ characterClassItem.kind }`);
+	}
+
 	for (const item of characterClassItem.body) {
 		switch (item.type) {
 			case 'value':
-				set.add(item.codePoint);
+				set = handlePositive.single(set, item.codePoint);
 				if (config.flags.ignoreCase && config.transform.unicodeFlag) {
 					const folded = caseFold(item.codePoint);
 					if (folded) {
-						set.add(folded);
+						set = handlePositive.single(set, folded);
 					}
 				}
 				break;
 			case 'characterClassRange':
 				const min = item.min.codePoint;
 				const max = item.max.codePoint;
-				set.addRange(min, max);
+				set = handlePositive.range(set, min, max);
 				if (config.flags.ignoreCase && config.transform.unicodeFlag) {
-					set.iuAddRange(min, max);
+					set = handlePositive.iuRange(set, min, max);
 				}
 				break;
 			case 'characterClassEscape':
-				set.add(getCharacterClassEscapeSet(
+				set = handlePositive.regSet(set, getCharacterClassEscapeSet(
 					item.value,
 					config.flags.unicode,
 					config.flags.ignoreCase
 				));
 				break;
 			case 'unicodePropertyEscape':
-				set.add(getUnicodePropertyEscapeSet(item.value, item.negative));
+				set = handlePositive.regSet(set, getUnicodePropertyEscapeSet(item.value, item.negative));
 				if (config.transform.unicodePropertyEscapes) {
 					transformed = true;
 				}
+				break;
+			case 'characterClass':
+				const handler = item.negative ? handleNegative : handlePositive;
+				const res = computeCharacterClass(item);
+				set = handler.regSet(set, res.set);
+				transformed = true;
 				break;
 			// The `default` clause is only here as a safeguard; it should never be
 			// reached. Code coverage tools should ignore it.
@@ -171,11 +254,27 @@ const processCharacterClass = (characterClassItem, regenerateOptions) => {
 				throw new Error(`Unknown term type: ${ item.type }`);
 		}
 	}
+
+	if (!set) { // /[]/
+		set = regenerate();
+	}
+
+	return { set, transformed };
+}
+
+const processCharacterClass = (characterClassItem, regenerateOptions) => {
+	const negative = characterClassItem.negative;
+	const { set, transformed } = computeCharacterClass(characterClassItem);
 	if (transformed) {
+		const setStr = set.toString(regenerateOptions);
 		if (negative) {
-			update(characterClassItem, `(?!${set.toString(regenerateOptions)})[\\s\\S]`)
+			if (config.useUnicodeFlag) {
+				update(characterClassItem, `[^${setStr.slice(1, -1)}]`)
+			} else {
+				update(characterClassItem, `(?!${setStr})[\\s\\S]`)
+			}
 		} else {
-			update(characterClassItem, set.toString(regenerateOptions));
+			update(characterClassItem, setStr);
 		}
 	}
 	return characterClassItem;
@@ -307,27 +406,22 @@ const processTerm = (item, regenerateOptions, groups) => {
 	return item;
 };
 
-// Enable every stable RegExp feature by default
-const regjsparserFeatures = {
-	'unicodePropertyEscape': true,
-	'namedGroups': true,
-	'lookbehind': true,
-};
-
 const config = {
 	'flags': {
 		'ignoreCase': false,
 		'unicode': false,
+		'unicodeSet': false,
 		'dotAll': false,
 	},
 	'transform': {
 		'dotAllFlag': false,
 		'unicodeFlag': false,
+		'unicodeSetFlag': false,
 		'unicodePropertyEscapes': false,
 		'namedGroups': false,
 	},
 	get useUnicodeFlag() {
-		return this.flags.unicode && !this.transform.unicodeFlag;
+		return (this.flags.unicode || this.flags.unicodeSet) && !this.transform.unicodeFlag;
 	}
 };
 
@@ -343,6 +437,11 @@ const validateOptions = (options) => {
 			case 'namedGroups':
 				if (value != null && value !== false && value !== 'transform') {
 					throw new Error(`.${key} must be false (default) or 'transform'.`);
+				}
+				break;
+			case 'unicodeSetFlag':
+				if (value != null && value !== false && value !== 'parse' && value !== 'transform') {
+					throw new Error(`.${key} must be false (default), 'parse' or 'transform'.`);
 				}
 				break;
 			case 'onNamedGroup':
@@ -363,21 +462,34 @@ const rewritePattern = (pattern, flags, options) => {
 	validateOptions(options);
 
 	config.flags.unicode = hasFlag(flags, 'u');
+	config.flags.unicodeSet = hasFlag(flags, 'v');
 	config.flags.ignoreCase = hasFlag(flags, 'i');
 	config.flags.dotAll = hasFlag(flags, 's');
 
 	config.transform.dotAllFlag = config.flags.dotAll && transform(options, 'dotAllFlag');
-	config.transform.unicodeFlag = config.flags.unicode && transform(options, 'unicodeFlag');
+	config.transform.unicodeFlag = (config.flags.unicode || config.flags.unicodeSet) && transform(options, 'unicodeFlag');
+	config.transform.unicodeSetFlag = config.flags.unicodeSet && transform(options, 'unicodeSetFlag');
+
 	// unicodeFlag: 'transform' implies unicodePropertyEscapes: 'transform'
 	config.transform.unicodePropertyEscapes = config.flags.unicode && (
 		transform(options, 'unicodeFlag') || transform(options, 'unicodePropertyEscapes')
 	);
 	config.transform.namedGroups = transform(options, 'namedGroups');
 
+	const regjsparserFeatures = {
+		'unicodeSet': Boolean(options && options.unicodeSetFlag),
+
+		// Enable every stable RegExp feature by default
+		'unicodePropertyEscape': true,
+		'namedGroups': true,
+		'lookbehind': true,
+	};
+
 	const regenerateOptions = {
-		'hasUnicodeFlag': config.flags.unicode && !config.transform.unicodeFlag,
+		'hasUnicodeFlag': config.useUnicodeFlag,
 		'bmpOnly': !config.flags.unicode
 	};
+
 	const groups = {
 		'onNamedGroup': options && options.onNamedGroup,
 		'lastIndex': 0,

--- a/rewrite-pattern.js
+++ b/rewrite-pattern.js
@@ -410,18 +410,18 @@ const config = {
 	'flags': {
 		'ignoreCase': false,
 		'unicode': false,
-		'unicodeSet': false,
+		'unicodeSets': false,
 		'dotAll': false,
 	},
 	'transform': {
 		'dotAllFlag': false,
 		'unicodeFlag': false,
-		'unicodeSetFlag': false,
+		'unicodeSetsFlag': false,
 		'unicodePropertyEscapes': false,
 		'namedGroups': false,
 	},
 	get useUnicodeFlag() {
-		return (this.flags.unicode || this.flags.unicodeSet) && !this.transform.unicodeFlag;
+		return (this.flags.unicode || this.flags.unicodeSets) && !this.transform.unicodeFlag;
 	}
 };
 
@@ -439,7 +439,7 @@ const validateOptions = (options) => {
 					throw new Error(`.${key} must be false (default) or 'transform'.`);
 				}
 				break;
-			case 'unicodeSetFlag':
+			case 'unicodeSetsFlag':
 				if (value != null && value !== false && value !== 'parse' && value !== 'transform') {
 					throw new Error(`.${key} must be false (default), 'parse' or 'transform'.`);
 				}
@@ -462,13 +462,13 @@ const rewritePattern = (pattern, flags, options) => {
 	validateOptions(options);
 
 	config.flags.unicode = hasFlag(flags, 'u');
-	config.flags.unicodeSet = hasFlag(flags, 'v');
+	config.flags.unicodeSets = hasFlag(flags, 'v');
 	config.flags.ignoreCase = hasFlag(flags, 'i');
 	config.flags.dotAll = hasFlag(flags, 's');
 
 	config.transform.dotAllFlag = config.flags.dotAll && transform(options, 'dotAllFlag');
-	config.transform.unicodeFlag = (config.flags.unicode || config.flags.unicodeSet) && transform(options, 'unicodeFlag');
-	config.transform.unicodeSetFlag = config.flags.unicodeSet && transform(options, 'unicodeSetFlag');
+	config.transform.unicodeFlag = (config.flags.unicode || config.flags.unicodeSets) && transform(options, 'unicodeFlag');
+	config.transform.unicodeSetsFlag = config.flags.unicodeSets && transform(options, 'unicodeSetsFlag');
 
 	// unicodeFlag: 'transform' implies unicodePropertyEscapes: 'transform'
 	config.transform.unicodePropertyEscapes = config.flags.unicode && (
@@ -477,7 +477,7 @@ const rewritePattern = (pattern, flags, options) => {
 	config.transform.namedGroups = transform(options, 'namedGroups');
 
 	const regjsparserFeatures = {
-		'unicodeSet': Boolean(options && options.unicodeSetFlag),
+		'unicodeSet': Boolean(options && options.unicodeSetsFlag),
 
 		// Enable every stable RegExp feature by default
 		'unicodePropertyEscape': true,

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1001,7 +1001,7 @@ describe('character classes', () => {
 	}
 });
 
-const TRANSFORM_U = { unicodeFlag: 'transform', unicodeSetFlag: 'transform' };
+const TRANSFORM_U = { unicodeFlag: 'transform', unicodeSetsFlag: 'transform' };
 
 const unicodeSetFixtures = [
 	{
@@ -1116,11 +1116,11 @@ const unicodeSetFixtures = [
 	},
 ];
 
-describe('unicode set (v) flag', () => {
+describe('unicodeSets (v) flag', () => {
 	for (const fixture of unicodeSetFixtures) {
 		const pattern = fixture.pattern;
 		const flags = fixture.flags || 'v';
-		const options = fixture.options || { unicodeSetFlag: 'transform' };
+		const options = fixture.options || { unicodeSetsFlag: 'transform' };
 		const transformUnicodeFlag = options.unicodeFlag === 'transform';
 		it('rewrites `/' + pattern + '/' + flags + '` correctly ' + (transformUnicodeFlag ? 'without ' : '') + 'using the u flag', () => {
 			const transpiled = rewritePattern(pattern, flags, options);

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1001,3 +1001,134 @@ describe('character classes', () => {
 	}
 });
 
+const TRANSFORM_U = { unicodeFlag: 'transform', unicodeSetFlag: 'transform' };
+
+const unicodeSetFixtures = [
+	{
+		pattern: '[[a-h]&&[f-z]]',
+		expected: '[f-h]'
+	},
+	{
+		pattern: '[[a-h]&&[f-z]&&[p-z]]',
+		expected: '[]'
+	},
+	{
+		pattern: '[[a-h]&&[b]]',
+		expected: 'b'
+	},
+	{
+		pattern: '[[a-h]&&b]',
+		expected: 'b'
+	},
+	{
+		pattern: '[[g-z]&&b]',
+		expected: '[]'
+	},
+	{
+		pattern: '[[a-h]&&[^f-z]]',
+		expected: '[a-e]'
+	},
+	{
+		pattern: '[[a-h]&&[^f-z]&&[p-z]]',
+		expected: '[]'
+	},
+	{
+		pattern: '[[a-h]&&[^f-z]&&[^p-z]]',
+		expected: '[a-e]'
+	},
+	{
+		pattern: '[[a-h]&&[^b]]',
+		expected: '[ac-h]'
+	},
+	{
+		pattern: '[[a-h]--[f-z]]',
+		expected: '[a-e]'
+	},
+	{
+		pattern: '[[a-h]--[f-z]--[p-z]]',
+		expected: '[a-e]'
+	},
+	{
+		pattern: '[[a-z]--[d-k]--[s-w]]',
+		expected: '[a-cl-rx-z]'
+	},
+	{
+		pattern: '[[a-h]--[b]]',
+		expected: '[ac-h]'
+	},
+	{
+		pattern: '[[b]--[a-h]]',
+		expected: '[]'
+	},
+	{
+		pattern: '[[a-h]--b]',
+		expected: '[ac-h]'
+	},
+	{
+		pattern: '[b--[a-h]]',
+		expected: '[]'
+	},
+	{
+		pattern: '[[g-z]--b]',
+		expected: '[g-z]'
+	},
+	{
+		pattern: '[b--[g-z]]',
+		expected: 'b'
+	},
+	{
+		pattern: '[[a-h]--[^f-z]]',
+		expected: '[f-h]'
+	},
+	{
+		pattern: '[[a-h]--[^f-z]--[p-z]]',
+		expected: '[f-h]'
+	},
+	{
+		pattern: '[[a-h]--[^f-z]--[^p-z]]',
+		expected: '[]'
+	},
+	{
+		pattern: '[[a-h]--[^b]]',
+		expected: 'b'
+	},
+	{
+		pattern: '[[a-z][f-h]]',
+		expected: '[a-z]'
+	},
+	{
+		pattern: '[^[a-z][f-h]]',
+		expected: '[^a-z]'
+	},
+	{
+		pattern: '[^[a-z][f-h]]',
+		expected: '(?:(?![a-z])[\\s\\S])',
+		options: TRANSFORM_U
+	},
+	{
+		pattern: '[[^a-z][f-h]]',
+		expected: '[\\0-`f-h\\{-\\u{10FFFF}]'
+	},
+	{
+		pattern: '[[^a-z][f-h]]',
+		expected: '(?:[\\0-`f-h\\{-\\uFFFF]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF])',
+		options: TRANSFORM_U
+	},
+];
+
+describe('unicode set (v) flag', () => {
+	for (const fixture of unicodeSetFixtures) {
+		const pattern = fixture.pattern;
+		const flags = fixture.flags || 'v';
+		const options = fixture.options || { unicodeSetFlag: 'transform' };
+		const transformUnicodeFlag = options.unicodeFlag === 'transform';
+		it('rewrites `/' + pattern + '/' + flags + '` correctly ' + (transformUnicodeFlag ? 'without ' : '') + 'using the u flag', () => {
+			const transpiled = rewritePattern(pattern, flags, options);
+			const expected = fixture.expected;
+			if (transpiled != '(?:' + expected + ')') {
+				assert.strictEqual(transpiled, expected);
+			}
+		});
+	}
+});
+


### PR DESCRIPTION
This adds support for `&&` and `||`. It doesn't support string alternatives in sets (`[\q{ab|cd}]`) or the updates to `\p`: I'll open other PRs for them.

I'm marking this as a wip because:
- [x] It depends on #49 (only the fourth commit is actually for this PR, the other three are from #49)
- [x] I need to add more tests