### PR TITLE
Support strings in sets in `v` mode

### DIFF
--- a/demo.js
+++ b/demo.js
@@ -5,7 +5,7 @@ const parse = require('regjsparser').parse;
 const generate = require('regjsgen').generate;
 const regenerate = require('regenerate');
 
-const pattern = String.raw`[[a-h]&&[f-z]]`;
+const pattern = String.raw`[[a-h]\q{👩🏿‍✈️|🚲|🇧🇪}]`;
 
 const processedPattern = rewritePattern(pattern, 'v', {
 	'unicodeSetsFlag': 'transform'


### PR DESCRIPTION
This PR introduces support for `\q{...}` in `v` sets.

Depens on #52 (the first commit is part of that PR; only review the second one)