### PR TITLE
Add support for `\p` Unicode properties of strings

### DIFF
--- a/demo.js
+++ b/demo.js
@@ -5,7 +5,7 @@ const parse = require('regjsparser').parse;
 const generate = require('regjsgen').generate;
 const regenerate = require('regenerate');
 
-const pattern = String.raw`[[a-h]\q{👩🏿‍✈️|🚲|🇧🇪}]`;
+const pattern = String.raw`[\p{Basic_Emoji}&&\q{😷|©️|dog}]`;
 
 const processedPattern = rewritePattern(pattern, 'v', {
 	'unicodeSetsFlag': 'transform'

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 	},
 	"dependencies": {
 		"regenerate": "^1.4.2",
-		"regenerate-unicode-properties": "^9.0.0",
+		"regenerate-unicode-properties": "^10.0.1",
 		"regjsgen": "^0.6.0",
 		"regjsparser": "^0.8.2",
 		"unicode-match-property-ecmascript": "^2.0.0",

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -542,18 +542,16 @@ describe('unicodePropertyEscapes', () => {
 			const p = `\\p{${ pattern }}`;
 			it('rewrites `/' + p + '/u` correctly', () => {
 				const transpiled = rewritePattern(p, 'u', features);
-				assert(
-					transpiled == expected.p ||
-					transpiled == '(?:' + expected.p + ')'
-				);
+				if (transpiled != '(?:' + expected.p + ')') {
+					assert.equal(transpiled, expected.p);
+				}
 			});
 			const P = `\\P{${ pattern }}`;
 			it('rewrites `/' + P + '/u` correctly', () => {
 				const transpiled = rewritePattern(P, 'u', features);
-				assert(
-					transpiled == expected.P ||
-					transpiled == '(?:' + expected.P + ')'
-				);
+				if (transpiled != '(?:' + expected.P + ')') {
+					assert.equal(transpiled, expected.P);
+				}
 			});
 		}
 	}
@@ -1003,6 +1001,12 @@ describe('character classes', () => {
 
 const TRANSFORM_U = { unicodeFlag: 'transform', unicodeSetsFlag: 'transform' };
 
+const Basic_Emoji = {
+	get all() { return `${this.strings}|[${this.chars}]` },
+	strings: "🅰️|🅱️|🅾️|🅿️|🈂️|🈷️|🌡️|🌤️|🌥️|🌦️|🌧️|🌨️|🌩️|🌪️|🌫️|🌬️|🌶️|🍽️|🎖️|🎗️|🎙️|🎚️|🎛️|🎞️|🎟️|🏋️|🏌️|🏍️|🏎️|🏔️|🏕️|🏖️|🏗️|🏘️|🏙️|🏚️|🏛️|🏜️|🏝️|🏞️|🏟️|🏳️|🏵️|🏷️|🐿️|👁️|📽️|🕉️|🕊️|🕯️|🕰️|🕳️|🕴️|🕵️|🕶️|🕷️|🕸️|🕹️|🖇️|🖊️|🖋️|🖌️|🖍️|🖐️|🖥️|🖨️|🖱️|🖲️|🖼️|🗂️|🗃️|🗄️|🗑️|🗒️|🗓️|🗜️|🗝️|🗞️|🗡️|🗣️|🗨️|🗯️|🗳️|🗺️|🛋️|🛍️|🛎️|🛏️|🛠️|🛡️|🛢️|🛣️|🛤️|🛥️|🛩️|🛰️|🛳️|©️|®️|‼️|⁉️|™️|ℹ️|↔️|↕️|↖️|↗️|↘️|↙️|↩️|↪️|⌨️|⏏️|⏭️|⏮️|⏯️|⏱️|⏲️|⏸️|⏹️|⏺️|Ⓜ️|▪️|▫️|▶️|◀️|◻️|◼️|☀️|☁️|☂️|☃️|☄️|☎️|☑️|☘️|☝️|☠️|☢️|☣️|☦️|☪️|☮️|☯️|☸️|☹️|☺️|♀️|♂️|♟️|♠️|♣️|♥️|♦️|♨️|♻️|♾️|⚒️|⚔️|⚕️|⚖️|⚗️|⚙️|⚛️|⚜️|⚠️|⚧️|⚰️|⚱️|⛈️|⛏️|⛑️|⛓️|⛩️|⛰️|⛱️|⛴️|⛷️|⛸️|⛹️|✂️|✈️|✉️|✌️|✍️|✏️|✒️|✔️|✖️|✝️|✡️|✳️|✴️|❄️|❇️|❣️|❤️|➡️|⤴️|⤵️|⬅️|⬆️|⬇️|〰️|〽️|㊗️|㊙️",
+	chars: "\\u231A\\u231B\\u23E9-\\u23EC\\u23F0\\u23F3\\u25FD\\u25FE\\u2614\\u2615\\u2648-\\u2653\\u267F\\u2693\\u26A1\\u26AA\\u26AB\\u26BD\\u26BE\\u26C4\\u26C5\\u26CE\\u26D4\\u26EA\\u26F2\\u26F3\\u26F5\\u26FA\\u26FD\\u2705\\u270A\\u270B\\u2728\\u274C\\u274E\\u2753-\\u2755\\u2757\\u2795-\\u2797\\u27B0\\u27BF\\u2B1B\\u2B1C\\u2B50\\u2B55\\u{1F004}\\u{1F0CF}\\u{1F18E}\\u{1F191}-\\u{1F19A}\\u{1F201}\\u{1F21A}\\u{1F22F}\\u{1F232}-\\u{1F236}\\u{1F238}-\\u{1F23A}\\u{1F250}\\u{1F251}\\u{1F300}-\\u{1F320}\\u{1F32D}-\\u{1F335}\\u{1F337}-\\u{1F37C}\\u{1F37E}-\\u{1F393}\\u{1F3A0}-\\u{1F3CA}\\u{1F3CF}-\\u{1F3D3}\\u{1F3E0}-\\u{1F3F0}\\u{1F3F4}\\u{1F3F8}-\\u{1F43E}\\u{1F440}\\u{1F442}-\\u{1F4FC}\\u{1F4FF}-\\u{1F53D}\\u{1F54B}-\\u{1F54E}\\u{1F550}-\\u{1F567}\\u{1F57A}\\u{1F595}\\u{1F596}\\u{1F5A4}\\u{1F5FB}-\\u{1F64F}\\u{1F680}-\\u{1F6C5}\\u{1F6CC}\\u{1F6D0}-\\u{1F6D2}\\u{1F6D5}-\\u{1F6D7}\\u{1F6DD}-\\u{1F6DF}\\u{1F6EB}\\u{1F6EC}\\u{1F6F4}-\\u{1F6FC}\\u{1F7E0}-\\u{1F7EB}\\u{1F7F0}\\u{1F90C}-\\u{1F93A}\\u{1F93C}-\\u{1F945}\\u{1F947}-\\u{1F9FF}\\u{1FA70}-\\u{1FA74}\\u{1FA78}-\\u{1FA7C}\\u{1FA80}-\\u{1FA86}\\u{1FA90}-\\u{1FAAC}\\u{1FAB0}-\\u{1FABA}\\u{1FAC0}-\\u{1FAC5}\\u{1FAD0}-\\u{1FAD9}\\u{1FAE0}-\\u{1FAE7}\\u{1FAF0}-\\u{1FAF6}"
+};
+
 const unicodeSetFixtures = [
 	{
 		pattern: '[[a-h]&&[f-z]]',
@@ -1276,6 +1280,50 @@ const unicodeSetFixtures = [
 	{
 		pattern: '[^\\q{}&&\\q{ab}]',
 		throws: /Cannot negate set containing strings/
+	},
+	{
+		pattern: '\\p{Basic_Emoji}',
+		expected: `(?:${Basic_Emoji.all})`
+	},
+	{
+		pattern: '[\\p{Basic_Emoji}]',
+		expected: `(?:${Basic_Emoji.all})`
+	},
+	{
+		pattern: '[\\p{Basic_Emoji}&&\\p{Basic_Emoji}]',
+		expected: `(?:${Basic_Emoji.all})`
+	},
+	{
+		pattern: '[\\p{Basic_Emoji}&&[\\u{0}-\\u{10ffff}]]',
+		expected: `[${Basic_Emoji.chars}]`
+	},
+	{
+		pattern: '[\\p{Basic_Emoji}\\p{Emoji}]',
+		expected: `(?:${Basic_Emoji.strings}|[#\\*0-9\\xA9\\xAE\\u203C\\u2049\\u2122\\u2139\\u2194-\\u2199\\u21A9\\u21AA\\u231A\\u231B\\u2328\\u23CF\\u23E9-\\u23F3\\u23F8-\\u23FA\\u24C2\\u25AA\\u25AB\\u25B6\\u25C0\\u25FB-\\u25FE\\u2600-\\u2604\\u260E\\u2611\\u2614\\u2615\\u2618\\u261D\\u2620\\u2622\\u2623\\u2626\\u262A\\u262E\\u262F\\u2638-\\u263A\\u2640\\u2642\\u2648-\\u2653\\u265F\\u2660\\u2663\\u2665\\u2666\\u2668\\u267B\\u267E\\u267F\\u2692-\\u2697\\u2699\\u269B\\u269C\\u26A0\\u26A1\\u26A7\\u26AA\\u26AB\\u26B0\\u26B1\\u26BD\\u26BE\\u26C4\\u26C5\\u26C8\\u26CE\\u26CF\\u26D1\\u26D3\\u26D4\\u26E9\\u26EA\\u26F0-\\u26F5\\u26F7-\\u26FA\\u26FD\\u2702\\u2705\\u2708-\\u270D\\u270F\\u2712\\u2714\\u2716\\u271D\\u2721\\u2728\\u2733\\u2734\\u2744\\u2747\\u274C\\u274E\\u2753-\\u2755\\u2757\\u2763\\u2764\\u2795-\\u2797\\u27A1\\u27B0\\u27BF\\u2934\\u2935\\u2B05-\\u2B07\\u2B1B\\u2B1C\\u2B50\\u2B55\\u3030\\u303D\\u3297\\u3299\\u{1F004}\\u{1F0CF}\\u{1F170}\\u{1F171}\\u{1F17E}\\u{1F17F}\\u{1F18E}\\u{1F191}-\\u{1F19A}\\u{1F1E6}-\\u{1F1FF}\\u{1F201}\\u{1F202}\\u{1F21A}\\u{1F22F}\\u{1F232}-\\u{1F23A}\\u{1F250}\\u{1F251}\\u{1F300}-\\u{1F321}\\u{1F324}-\\u{1F393}\\u{1F396}\\u{1F397}\\u{1F399}-\\u{1F39B}\\u{1F39E}-\\u{1F3F0}\\u{1F3F3}-\\u{1F3F5}\\u{1F3F7}-\\u{1F4FD}\\u{1F4FF}-\\u{1F53D}\\u{1F549}-\\u{1F54E}\\u{1F550}-\\u{1F567}\\u{1F56F}\\u{1F570}\\u{1F573}-\\u{1F57A}\\u{1F587}\\u{1F58A}-\\u{1F58D}\\u{1F590}\\u{1F595}\\u{1F596}\\u{1F5A4}\\u{1F5A5}\\u{1F5A8}\\u{1F5B1}\\u{1F5B2}\\u{1F5BC}\\u{1F5C2}-\\u{1F5C4}\\u{1F5D1}-\\u{1F5D3}\\u{1F5DC}-\\u{1F5DE}\\u{1F5E1}\\u{1F5E3}\\u{1F5E8}\\u{1F5EF}\\u{1F5F3}\\u{1F5FA}-\\u{1F64F}\\u{1F680}-\\u{1F6C5}\\u{1F6CB}-\\u{1F6D2}\\u{1F6D5}-\\u{1F6D7}\\u{1F6DD}-\\u{1F6E5}\\u{1F6E9}\\u{1F6EB}\\u{1F6EC}\\u{1F6F0}\\u{1F6F3}-\\u{1F6FC}\\u{1F7E0}-\\u{1F7EB}\\u{1F7F0}\\u{1F90C}-\\u{1F93A}\\u{1F93C}-\\u{1F945}\\u{1F947}-\\u{1F9FF}\\u{1FA70}-\\u{1FA74}\\u{1FA78}-\\u{1FA7C}\\u{1FA80}-\\u{1FA86}\\u{1FA90}-\\u{1FAAC}\\u{1FAB0}-\\u{1FABA}\\u{1FAC0}-\\u{1FAC5}\\u{1FAD0}-\\u{1FAD9}\\u{1FAE0}-\\u{1FAE7}\\u{1FAF0}-\\u{1FAF6}])`
+	},
+	{
+		pattern: '[\\p{Basic_Emoji}&&\\q{🇮🇴|dog}]',
+		expected: '[]'
+	},
+	{
+		pattern: '[\\p{RGI_Emoji_Flag_Sequence}&&\\q{🇮🇴|dog}]',
+		expected: '🇮🇴'
+	},
+	{
+		pattern: '[\\p{Basic_Emoji}\\q{JavaScript|ECMAScript}]',
+		expected: `(?:JavaScript|ECMAScript|${Basic_Emoji.all})`
+	},
+	{
+		pattern: '[\\p{Basic_Emoji}&&\\q{😷|©️|dog}]',
+		expected: '(?:©️|\\u{1F637})'
+	},
+	{
+		pattern: '\\P{Basic_Emoji}',
+		throws: /Cannot negate Unicode property of strings/
+	},
+	{
+		pattern: '[^\\p{Basic_Emoji}]',
+		throws: /Cannot negate set containing strings/
 	}
 ];
 
@@ -1309,5 +1357,11 @@ describe('unicodeSets (v) flag', () => {
 			});
 		}
 	}
+
+	it('Property of strings used without the v flag', () => {
+		assert.throws(() => {
+			rewritePattern('\\p{Basic_Emoji}', 'u')
+		}, /Properties of strings are only supported when using the unicodeSets \(v\) flag/);
+	})
 });
 


### PR DESCRIPTION
All the new files in `data/` are generated by `scripts/sequence-properties.js`.

I coped the list of properties from Table 69 of https://arai-a.github.io/ecma262-compare/?pr=2418, is it correct?