### PR TITLE
Ensure Node.js 6 compatibility

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,3 +37,16 @@ jobs:
           node-version: ${{ matrix.node }}
       - name: Test
         run: npm test
+
+  node-6-compat:
+    runs-on: ubuntu-latest
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Node.js 6
+        uses: actions/setup-node@v1
+        with:
+          node-version: 6
+      - name: Install dependencies
+        run: npm install
+      - name: Run demo.js
+        run: node demo.js

--- a/rewrite-pattern.js
+++ b/rewrite-pattern.js
@@ -423,7 +423,7 @@ const computeCharacterClass = (characterClassItem, regenerateOptions) => {
 const processCharacterClass = (
 	characterClassItem,
 	regenerateOptions,
-	computed = computeCharacterClass(characterClassItem, regenerateOptions),
+	computed = computeCharacterClass(characterClassItem, regenerateOptions)
 ) => {
 	const negative = characterClassItem.negative;
 	const { singleChars, transformed, longStrings } = computed;


### PR DESCRIPTION
I'm sorry, I know that this is annoying. Babel 7 still supports Node.js 6, which is painful but we don't want to drop it until the next major (Babel 8 will only support Node.js 12+, or Node.js 14+).

`regexpu-core` is _almost_ compatible with Node.js 6, except for an ES2017 trailing comma I introduced in one of my recent pull requests. This PR makes it work again, and adds a small test (it just runs `demo.js`, because mocha requires a newer Node.js version) to make sure that we don't accidentally use unsupported syntax.