### PR TITLE
Fix parsing of named refs when not transforming named groups

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -943,12 +943,35 @@ describe('namedGroups', () => {
 	});
 
 	it('should not transpile when namedGroups is not enabled', () => {
+		const pattern = '(?<name>)';
 		let transpiled;
-		const expected = '(?<name>)';
 		assert.doesNotThrow(() => {
-			transpiled = rewritePattern('(?<name>)', '');
+			transpiled = rewritePattern(pattern, '');
 		});
-		assert.strictEqual(expected, transpiled);
+		assert.strictEqual(pattern, transpiled);
+	});
+
+	it('should support named group references when namedGroups is not enabled', () => {
+		const pattern = '(?<name>)\\k<name>';
+		let transpiled;
+		assert.doesNotThrow(() => {
+			transpiled = rewritePattern(pattern, '');
+		});
+		assert.strictEqual(pattern, transpiled);
+	});
+
+	it('should validate named group references when namedGroups is not enabled', () => {
+		assert.throws(() => rewritePattern('\\k<foo>', ''), /Unknown group names: foo/);
+	});
+
+	it('shold call onNamedGroup even if namedGroups is not enabled', () => {
+		let called = false;
+		rewritePattern('(?<name>)', '', {
+			onNamedGroup() {
+				called = true;
+			},
+		});
+		assert.strictEqual(called, true);
 	})
 });
 


### PR DESCRIPTION
Fixes #59 

The names tracking logic was only enabled when transforming named groups; this commit always enables it. I suggest reviewing [without whitespace changes](https://github.com/mathiasbynens/regexpu-core/pull/67/files?w=1), since many changes are just indentation.