### PR TITLE
fix: astral handling on character class negation

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
 		"jsesc": "^3.0.2",
 		"lodash": "^4.17.21",
 		"mocha": "^10.1.0",
-		"regexpu-fixtures": "2.1.4",
+		"regexpu-fixtures": "mathiasbynens/regexpu-fixtures",
 		"@unicode/unicode-15.0.0": "^1.3.1"
 	}
 }

--- a/rewrite-pattern.js
+++ b/rewrite-pattern.js
@@ -497,7 +497,7 @@ const processCharacterClass = (
 						const astralCharsSet = singleChars.clone().intersection(ASTRAL_SET);
 						// Assumption: singleChars do not contain lone surrogates.
 						// Regex like /[^\ud800]/u is not supported
-						const SurrogateOrBMPSetStr = singleChars
+						const surrogateOrBMPSetStr = singleChars
 							.clone()
 							.remove(astralCharsSet)
 							.addRange(0xd800, 0xdfff)
@@ -512,7 +512,7 @@ const processCharacterClass = (
 						// The transform here does not support lone surrogates.
 						update(
 							characterClassItem,
-							`(?!${SurrogateOrBMPSetStr})[\\s\\S]|${astralNegativeSetStr}`
+							`(?!${surrogateOrBMPSetStr})[\\s\\S]|${astralNegativeSetStr}`
 						);
 					} else {
 						// Generate negative set directly when case folding is not involved.

--- a/rewrite-pattern.js
+++ b/rewrite-pattern.js
@@ -27,6 +27,8 @@ const SPECIAL_CHARS = /([\\^$.*+?()[\]{}|])/g;
 // character classes (if any).
 const UNICODE_SET = regenerate().addRange(0x0, 0x10FFFF);
 
+const ASTRAL_SET = regenerate().addRange(0x10000, 0x10FFFF);
+
 const NEWLINE_SET = regenerate().add(
 	// `LineTerminator`s (https://mths.be/es6#sec-line-terminators):
 	0x000A, // Line Feed <LF>
@@ -490,7 +492,38 @@ const processCharacterClass = (
 			if (config.useUnicodeFlag) {
 				update(characterClassItem, `[^${setStr[0] === '[' ? setStr.slice(1, -1) : setStr}]`)
 			} else {
-				update(characterClassItem, `(?!${setStr})[\\s\\S]`)
+				if (config.flags.unicode) {
+					if (config.flags.ignoreCase) {
+						const astralCharsSet = singleChars.clone().intersection(ASTRAL_SET);
+						// Assumption: singleChars do not contain lone surrogates.
+						// Regex like /[^\ud800]/u is not supported
+						const SurrogateOrBMPSetStr = singleChars
+							.clone()
+							.remove(astralCharsSet)
+							.addRange(0xd800, 0xdfff)
+							.toString({ bmpOnly: true });
+						// Don't generate negative lookahead for astral characters
+						// because the case folding is not working anyway as we break
+						// code points into surrogate pairs.
+						const astralNegativeSetStr = ASTRAL_SET
+							.clone()
+							.remove(astralCharsSet)
+							.toString(regenerateOptions);
+						// The transform here does not support lone surrogates.
+						update(
+							characterClassItem,
+							`(?!${SurrogateOrBMPSetStr})[\\s\\S]|${astralNegativeSetStr}`
+						);
+					} else {
+						// Generate negative set directly when case folding is not involved.
+						update(
+							characterClassItem,
+							UNICODE_SET.clone().remove(singleChars).toString(regenerateOptions)
+						);
+					}
+				} else {
+					update(characterClassItem, `(?!${setStr})[\\s\\S]`);
+				}
 			}
 		} else {
 			const hasEmptyString = longStrings.has('');

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -588,7 +588,7 @@ describe('unicodePropertyEscapes', () => {
 		);
 		assert.equal(
 			rewritePattern('[^\\p{ASCII_Hex_Digit}_]', 'u', features),
-			'(?:(?![0-9A-F_a-f])[\\s\\S])'
+			'(?:[\\0-\\/:-@G-\\^`g-\\uD7FF\\uE000-\\uFFFF]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF]|[\\uD800-\\uDBFF](?![\\uDC00-\\uDFFF])|(?:[^\\uD800-\\uDBFF]|^)[\\uDC00-\\uDFFF])'
 		);
 		assert.equal(
 			rewritePattern('[\\P{Script_Extensions=Anatolian_Hieroglyphs}]', 'u', features),
@@ -753,25 +753,25 @@ const dotAllFlagFixtures = [
 		'pattern': '.',
 		'flags': 's',
 		'expected': '[\\s\\S]',
-		'options': { unicodeFlag: 'transform' }
+		options: { unicodeFlag: 'transform' }
 	},
 	{
 		'pattern': '.',
 		'flags': 'gimsy',
 		'expected': '[\\s\\S]',
-		'options': { unicodeFlag: 'transform' }
+		options: { unicodeFlag: 'transform' }
 	},
 	{
 		'pattern': '.',
 		'flags': 'su',
 		'expected': UNICODE_PATTERN,
-		'options': { unicodeFlag: 'transform' }
+		options: { unicodeFlag: 'transform' }
 	},
 	{
 		'pattern': '.',
 		'flags': 'gimsuy',
 		'expected': UNICODE_PATTERN,
-		'options': { unicodeFlag: 'transform' }
+		options: { unicodeFlag: 'transform' }
 	}
 ];
 
@@ -989,74 +989,92 @@ const characterClassFixtures = [
 	{
 		pattern: '[^K]', // LATIN CAPITAL LETTER K
 		flags: 'iu',
-		expected: '(?![K\\u212A])[\\s\\S]',
-		'options': { unicodeFlag: 'transform' }
+		expected: '(?:(?![K\\u212A\\uD800-\\uDFFF])[\\s\\S]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF])',
+		options: { unicodeFlag: 'transform' }
 	},
 	{
 		pattern: '[^k]', // LATIN SMALL LETTER K
 		flags: 'iu',
-		expected: '(?![k\\u212A])[\\s\\S]',
-		'options': { unicodeFlag: 'transform' }
+		expected: '(?:(?![k\\u212A\\uD800-\\uDFFF])[\\s\\S]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF])',
+		options: { unicodeFlag: 'transform' }
 	},
 	{
 		pattern: '[^\u212a]', // KELVIN SIGN
 		flags: 'iu',
-		expected: '(?![K\\u212A])[\\s\\S]',
-		'options': { unicodeFlag: 'transform' }
+		expected: '(?:(?![K\\u212A\\uD800-\\uDFFF])[\\s\\S]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF])',
+		options: { unicodeFlag: 'transform' }
 	},
 	{
 		pattern: '[^K]', // LATIN CAPITAL LETTER K
 		flags: 'iu',
 		expected: '[^K]',
-		'options': {}
+		options: {}
 	},
 	{
 		pattern: '[^k]', // LATIN SMALL LETTER K
 		flags: 'iu',
 		expected: '[^k]',
-		'options': {}
+		options: {}
 	},
 	{
 		pattern: '[^\u212a]', // KELVIN SIGN
 		flags: 'iu',
 		expected: '[^\u212a]',
-		'options': {}
+		options: {}
+	},
+	{
+		pattern: '[^\u{1D50E}]', // MATHEMATICAL FRAKTUR CAPITAL K
+		flags: 'iu',
+		expected: '(?:(?![\\uD800-\\uDFFF])[\\s\\S]|[\\uD800-\\uD834\\uD836-\\uDBFF][\\uDC00-\\uDFFF]|\\uD835[\\uDC00-\\uDD0D\\uDD0F-\\uDFFF])',
+		options: { unicodeFlag: 'transform' }
 	},
 	{
 		pattern: '[^K]', // LATIN CAPITAL LETTER K
 		flags: 'u',
-		expected: '(?!K)[\\s\\S]',
-		'options': { unicodeFlag: 'transform' }
+		expected: '(?:[\\0-JL-\\uD7FF\\uE000-\\uFFFF]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF]|[\\uD800-\\uDBFF](?![\\uDC00-\\uDFFF])|(?:[^\\uD800-\\uDBFF]|^)[\\uDC00-\\uDFFF])',
+		options: { unicodeFlag: 'transform' }
 	},
 	{
 		pattern: '[^k]', // LATIN SMALL LETTER K
 		flags: 'u',
-		expected: '(?!k)[\\s\\S]',
-		'options': { unicodeFlag: 'transform' }
+		expected: '(?:[\\0-jl-\\uD7FF\\uE000-\\uFFFF]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF]|[\\uD800-\\uDBFF](?![\\uDC00-\\uDFFF])|(?:[^\\uD800-\\uDBFF]|^)[\\uDC00-\\uDFFF])',
+		options: { unicodeFlag: 'transform' }
 	},
 	{
 		pattern: '[^\u212a]', // KELVIN SIGN
 		flags: 'u',
-		expected: '(?!\\u212A)[\\s\\S]',
-		'options': { unicodeFlag: 'transform' }
+		expected: '(?:[\\0-\\u2129\\u212B-\\uD7FF\\uE000-\\uFFFF]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF]|[\\uD800-\\uDBFF](?![\\uDC00-\\uDFFF])|(?:[^\\uD800-\\uDBFF]|^)[\\uDC00-\\uDFFF])',
+		options: { unicodeFlag: 'transform' }
+	},
+	{
+		pattern: '[^\u{1D50E}]', // MATHEMATICAL FRAKTUR CAPITAL K
+		flags: 'u',
+		expected: '(?:[\\0-\\uD7FF\\uE000-\\uFFFF]|[\\uD800-\\uD834\\uD836-\\uDBFF][\\uDC00-\\uDFFF]|\\uD835[\\uDC00-\\uDD0D\\uDD0F-\\uDFFF]|[\\uD800-\\uDBFF](?![\\uDC00-\\uDFFF])|(?:[^\\uD800-\\uDBFF]|^)[\\uDC00-\\uDFFF])',
+		options: { unicodeFlag: 'transform' }
 	},
 	{
 		pattern: '[^K]', // LATIN CAPITAL LETTER K
 		flags: 'u',
 		expected: '[^K]',
-		'options': {}
+		options: {}
 	},
 	{
 		pattern: '[^k]', // LATIN SMALL LETTER K
 		flags: 'u',
 		expected: '[^k]',
-		'options': {}
+		options: {}
 	},
 	{
 		pattern: '[^\u212a]', // KELVIN SIGN
 		flags: 'u',
 		expected: '[^\u212a]',
-		'options': {}
+		options: {}
+	},
+	{
+		pattern: '[^\u{1D50E}]', // MATHEMATICAL FRAKTUR CAPITAL K
+		flags: 'u',
+		expected: '[^\u{1D50E}]',
+		options: {}
 	}
 ];
 


### PR DESCRIPTION
Fixes https://github.com/mathiasbynens/regexpu-core/issues/72
Fixes https://github.com/babel/babel/issues/15357

This is a regression introduced in #46. 
- Add basic astral handling for `/[^a-z]/u`, previously the astral characters are matched as surrogates (https://github.com/babel/babel/issues/15357)
- Resort to the previous negative set approach when the `i` flag is not enabled (https://github.com/babel/babel/issues/15357)

<s>Pending https://github.com/mathiasbynens/regexpu-fixtures/pull/3</s>