### PR TITLE
Support non-ASCII characters inside inline `i` clause

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1487,11 +1487,31 @@ const modifiersFixtures = [
 		'expected': '(?:[A-Za-z])',
 	},
 	{
+		'pattern': '(?i:[ab])',
+		'expected': '(?:[ABab])',
+	},
+	{
+		'pattern': '(?i:\\u212A)',
+		'expected': '(?:\\u212A)',
+	},
+	{
+		'pattern': '(?i:k)',
+		'flags': 'u',
+		'expected': '(?:[Kk\\u212A])',
+	},
+	{
 		'pattern': '(?i:[a-z])',
 		'flags': 'u',
 		'options':  { unicodeFlag: 'transform', modifiers: 'transform' },
 		'expected': '(?:[A-Za-z\\u017F\\u212A])',
 		'expectedFlags': '',
+	},
+	{
+		'pattern': '(?i:[ks])',
+		'flags': 'u',
+		'options':  { modifiers: 'transform' },
+		'expected': '(?:[KSks\\u017F\\u212A])',
+		'expectedFlags': 'u',
 	},
 	{
 		'pattern': '(?i:[\\q{ab|cd|abc}--\\q{abc}--\\q{cd}])',
@@ -1512,6 +1532,21 @@ const modifiersFixtures = [
 		'options':  { unicodeSetsFlag: 'transform', unicodeFlag: 'transform', modifiers: 'transform' },
 		'expected': '(?:(?:[Aa][Bb]))',
 		'expectedFlags': '',
+	},
+	{
+		'pattern': '(?i:є)',
+		'options': { modifiers: 'transform' },
+		'expected': '(?:[\\u0404\\u0454])',
+	},
+	{
+		'pattern': '(?i:[є-ґ])',
+		'options': { modifiers: 'transform' },
+		'expected': '(?:[\\u0404-\\u040F\\u0454-\\u0491])',
+	},
+	{
+		'pattern': '(?i:[Жщ])',
+		'options': { modifiers: 'transform' },
+		'expected': '(?:[\\u0416\\u0429\\u0436\\u0449])',
 	},
 	// +m
 	{


### PR DESCRIPTION
Okay, so after perusing the code a bit longer, I believe I've finally figured it out. This fixes #79 

The `configNeedCaseFoldUnicode` function, which indicates whether to take into account the implicit case folding of a string happening while setting both `i` and `u` flags, used to ignore `i` modifier being removed in a rewritten expression.

Inside the `caseFold` function, uppercase and lowercase versions of a symbol were only included if the symbol lied inside the ASCII range. Now, any symbol that case folds uniquely is processed properly.

Inside the `computeCharacterClass` function, `data` wasn't marked as transformed, despite having been augmented with case folded symbols, and therefore didn't alter the resulting expression.

At last, I renamed `configNeedCaseFoldUnicode` to `configNeedAccountForImplicitCaseFold`, as the function indicates if we
need to take the `iu` implicit case folding into account, and `configNeedCaseFoldAscii` to `configNeedExplicitCaseFold`, as the characters affected by it are no longer the ASCII ones.

Also, I've written several simple tests.

What do you think?