### PR TITLE
Fix v-flag bugs

### DIFF
--- a/rewrite-pattern.js
+++ b/rewrite-pattern.js
@@ -441,7 +441,7 @@ const computeCharacterClass = (characterClassItem, regenerateOptions) => {
 			case 'characterClassEscape':
 				handlePositive.regSet(data, getCharacterClassEscapeSet(
 					item.value,
-					config.flags.unicode,
+					config.flags.unicode || config.flags.unicodeSets,
 					config.flags.ignoreCase
 				));
 				break;
@@ -494,7 +494,7 @@ const processCharacterClass = (
 			if (config.useUnicodeFlag) {
 				update(characterClassItem, `[^${setStr[0] === '[' ? setStr.slice(1, -1) : setStr}]`)
 			} else {
-				if (config.flags.unicode) {
+				if (config.flags.unicode || config.flags.unicodeSets) {
 					if (config.flags.ignoreCase) {
 						const astralCharsSet = singleChars.clone().intersection(ASTRAL_SET);
 						// Assumption: singleChars do not contain lone surrogates.
@@ -835,7 +835,7 @@ const rewritePattern = (pattern, flags, options) => {
 
 	const regenerateOptions = {
 		'hasUnicodeFlag': config.useUnicodeFlag,
-		'bmpOnly': !config.flags.unicode
+		'bmpOnly': !config.flags.unicode && !config.flags.unicodeSets
 	};
 
 	const groups = {

--- a/rewrite-pattern.js
+++ b/rewrite-pattern.js
@@ -330,7 +330,7 @@ const buildHandler = (action) => {
 		}
 		// The `default` clause is only here as a safeguard; it should never be
 		// reached. Code coverage tools should ignore it.
-		/* istanbul ignore next */
+		/* node:coverage ignore next */
 		default:
 			throw new Error(`Unknown set action: ${ characterClassItem.kind }`);
 	}
@@ -414,7 +414,7 @@ const computeCharacterClass = (characterClassItem, regenerateOptions) => {
 			break;
 		// The `default` clause is only here as a safeguard; it should never be
 		// reached. Code coverage tools should ignore it.
-		/* istanbul ignore next */
+		/* node:coverage ignore next */
 		default:
 			throw new Error(`Unknown character class kind: ${ characterClassItem.kind }`);
 	}
@@ -465,7 +465,7 @@ const computeCharacterClass = (characterClassItem, regenerateOptions) => {
 				break;
 			// The `default` clause is only here as a safeguard; it should never be
 			// reached. Code coverage tools should ignore it.
-			/* istanbul ignore next */
+			/* node:coverage ignore next */
 			default:
 				throw new Error(`Unknown term type: ${ item.type }`);
 		}
@@ -731,7 +731,7 @@ const processTerm = (item, regenerateOptions, groups) => {
 			break;
 		// The `default` clause is only here as a safeguard; it should never be
 		// reached. Code coverage tools should ignore it.
-		/* istanbul ignore next */
+		/* node:coverage ignore next */
 		default:
 			throw new Error(`Unknown term type: ${ item.type }`);
 	}

--- a/rewrite-pattern.js
+++ b/rewrite-pattern.js
@@ -495,7 +495,7 @@ const processCharacterClass = (
 	if (transformed) {
 		// If single chars already contains some astral character, regenerate (bmpOnly: true) will create valid regex strings
 		const bmpOnly = regenerateContainsAstral(singleChars);
-		const setStr = singleChars.toString({ ...regenerateOptions, bmpOnly: bmpOnly });
+		const setStr = singleChars.toString(Object.assign({}, regenerateOptions, { bmpOnly: bmpOnly }));
 
 		if (negative) {
 			if (config.useUnicodeFlag) {

--- a/tests/fixtures/character-class.js
+++ b/tests/fixtures/character-class.js
@@ -44,25 +44,33 @@ const characterClassFixtures = [
 	{
 		pattern: '[^K]', // LATIN CAPITAL LETTER K
 		flags: 'u',
-		expected: '(?:[\\0-JL-\\uD7FF\\uE000-\\uFFFF]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF]|[\\uD800-\\uDBFF](?![\\uDC00-\\uDFFF])|(?:[^\\uD800-\\uDBFF]|^)[\\uDC00-\\uDFFF])',
+		matches: ["k", "\u212a", "\u{12345}", "\uDAAA", "\uDDDD"],
+		nonMatches: ["K"],
+		expected: '(?:[\\0-JL-\\uFFFF]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF])',
 		options: { unicodeFlag: 'transform' }
 	},
 	{
 		pattern: '[^k]', // LATIN SMALL LETTER K
 		flags: 'u',
-		expected: '(?:[\\0-jl-\\uD7FF\\uE000-\\uFFFF]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF]|[\\uD800-\\uDBFF](?![\\uDC00-\\uDFFF])|(?:[^\\uD800-\\uDBFF]|^)[\\uDC00-\\uDFFF])',
+		matches: ["K", "\u212a", "\u{12345}", "\uDAAA", "\uDDDD"],
+		nonMatches: ["k"],
+		expected: '(?:[\\0-jl-\\uFFFF]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF])',
 		options: { unicodeFlag: 'transform' }
 	},
 	{
 		pattern: '[^\u212a]', // KELVIN SIGN
 		flags: 'u',
-		expected: '(?:[\\0-\\u2129\\u212B-\\uD7FF\\uE000-\\uFFFF]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF]|[\\uD800-\\uDBFF](?![\\uDC00-\\uDFFF])|(?:[^\\uD800-\\uDBFF]|^)[\\uDC00-\\uDFFF])',
+		matches: ["K", "k", "\u{12345}", "\uDAAA", "\uDDDD"],
+		nonMatches: ["\u212a"],
+		expected: '(?:[\\0-\\u2129\\u212B-\\uFFFF]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF])',
 		options: { unicodeFlag: 'transform' }
 	},
 	{
 		pattern: '[^\u{1D50E}]', // MATHEMATICAL FRAKTUR CAPITAL K
 		flags: 'u',
-		expected: '(?:[\\0-\\uD7FF\\uE000-\\uFFFF]|[\\uD800-\\uD834\\uD836-\\uDBFF][\\uDC00-\\uDFFF]|\\uD835[\\uDC00-\\uDD0D\\uDD0F-\\uDFFF]|[\\uD800-\\uDBFF](?![\\uDC00-\\uDFFF])|(?:[^\\uD800-\\uDBFF]|^)[\\uDC00-\\uDFFF])',
+		matches: ["K", "k", "\u{12345}", "\u{1D50F}", "\uDAAA", "\uDDDD"],
+		nonMatches: ["\u{1D50E}"],
+		expected: '(?:[\\0-\\uFFFF]|[\\uD800-\\uD834\\uD836-\\uDBFF][\\uDC00-\\uDFFF]|\\uD835[\\uDC00-\\uDD0D\\uDD0F-\\uDFFF])',
 		options: { unicodeFlag: 'transform' }
 	},
 	{

--- a/tests/fixtures/unicode-set.js
+++ b/tests/fixtures/unicode-set.js
@@ -105,17 +105,21 @@ const unicodeSetFixtures = [
 	},
 	{
 		pattern: '[^[a-z][f-h]]',
-		matches: ["A", "\u{12345}"],
+		matches: ["A", "\u{12345}", "\uDAAA", "\uDDDD"],
 		nonMatches: ["a", "z"],
-		expected: '(?:(?![a-z])[\\s\\S])',
+		expected: '(?:[\\0-`\\{-\\uFFFF]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF])',
 		options: TRANSFORM_U
 	},
 	{
 		pattern: '[[^a-z][f-h]]',
+		matches: ["f", "A", "\u{12345}", "\uDAAA", "\uDDDD"],
+		nonMatches: ["a", "z"],
 		expected: '[\\0-`f-h\\{-\\u{10FFFF}]'
 	},
 	{
 		pattern: '[[^a-z][f-h]]',
+		matches: ["f", "A", "\u{12345}", "\uDAAA", "\uDDDD"],
+		nonMatches: ["a", "z"],
 		expected: '(?:[\\0-`f-h\\{-\\uFFFF]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF])',
 		options: TRANSFORM_U
 	},

--- a/tests/fixtures/unicode-set.js
+++ b/tests/fixtures/unicode-set.js
@@ -105,6 +105,8 @@ const unicodeSetFixtures = [
 	},
 	{
 		pattern: '[^[a-z][f-h]]',
+		matches: ["A", "\u{12345}"],
+		nonMatches: ["a", "z"],
 		expected: '(?:(?![a-z])[\\s\\S])',
 		options: TRANSFORM_U
 	},

--- a/tests/fixtures/unicode-set.js
+++ b/tests/fixtures/unicode-set.js
@@ -342,6 +342,13 @@ const unicodeSetFixtures = [
 	{
 		pattern: '[\\p{ASCII}&&\\p{Control}]',
 		expected: '[\\0-\\x1F\\x7F]',
+	},
+	{
+		pattern: '.',
+		flags: 'sv',
+		matches: ['\n'],
+		options: { unicodeSetsFlag: 'transform', dotAllFlag: 'transform' },
+		expected: '[\\s\\S]'
 	}
 ];
 

--- a/tests/fixtures/unicode.js
+++ b/tests/fixtures/unicode.js
@@ -44,7 +44,7 @@ const unicodeFixtures = [
 	{
 		'pattern': '[\\s\\S]',
 		'flags': FLAGS_WITH_UNICODE,
-		'transpiled': '(?:[\\0-\\uD7FF\\uE000-\\uFFFF]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF]|[\\uD800-\\uDBFF](?![\\uDC00-\\uDFFF])|(?:[^\\uD800-\\uDBFF]|^)[\\uDC00-\\uDFFF])'
+		'transpiled': '(?:[\\0-\\uFFFF]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF])'
 	},
 	{
 		'pattern': '\\d',
@@ -68,8 +68,9 @@ const unicodeFixtures = [
 	},
 	{
 		'pattern': '[\\d\\D]',
+		'matches': ["a", "0", "\u{12345}", "\uDAAA", "\uDDDD"],
 		'flags': FLAGS_WITH_UNICODE,
-		'transpiled': '(?:[\\0-\\uD7FF\\uE000-\\uFFFF]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF]|[\\uD800-\\uDBFF](?![\\uDC00-\\uDFFF])|(?:[^\\uD800-\\uDBFF]|^)[\\uDC00-\\uDFFF])'
+		'transpiled': '(?:[\\0-\\uFFFF]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF])'
 	},
 	{
 		'pattern': '\\w',
@@ -100,8 +101,9 @@ const unicodeFixtures = [
 	},
 	{
 		'pattern': '[\\w\\W]',
+		'matches': ["a", "0", "\u{12345}", "\uDAAA", "\uDDDD"],
 		'flags': FLAGS_WITH_UNICODE,
-		'transpiled': '(?:[\\0-\\uD7FF\\uE000-\\uFFFF]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF]|[\\uD800-\\uDBFF](?![\\uDC00-\\uDFFF])|(?:[^\\uD800-\\uDBFF]|^)[\\uDC00-\\uDFFF])'
+		'transpiled': '(?:[\\0-\\uFFFF]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF])'
 	},
 	{
 		'pattern': '[\\uD834\\uDF06-\\uD834\\uDF08a-z]',
@@ -180,11 +182,14 @@ const unicodeFixtures = [
 	},
 	{
 		'pattern': '[^a]',
+		'matches': ['b', 'A', '\u{1D49C}', '\uDAAA', '\uDDDD'],
+		'nonMatches': ['a'],
 		'flags': FLAGS_WITH_UNICODE_WITHOUT_I,
-		'transpiled': '(?:[\\0-`b-\\uD7FF\\uE000-\\uFFFF]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF]|[\\uD800-\\uDBFF](?![\\uDC00-\\uDFFF])|(?:[^\\uD800-\\uDBFF]|^)[\\uDC00-\\uDFFF])'
+		'transpiled': '(?:[\\0-`b-\\uFFFF]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF])'
 	},
 	{
 		'pattern': '[^a]',
+		'nonMatches': ['a', 'A'],
 		'flags': FLAGS_WITH_UNICODE_WITH_I,
 		'transpiled': '(?:(?![a\\uD800-\\uDFFF])[\\s\\S]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF])'
 	},

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -243,10 +243,10 @@ describe('unicodePropertyEscapes', () => {
 			'[\\u{14400}-\\u{14646}]'
 		);
 		assert.equal(
-			rewritePattern('[\\p{Script_Extensions=Anatolian_Hieroglyphs}]', 'u', {
+			rewritePattern('[\\P{Script_Extensions=Anatolian_Hieroglyphs}]', 'u', {
 				'unicodePropertyEscapes': 'transform',
 			}),
-			'[\\u{14400}-\\u{14646}]'
+			'[\\0-\\u{143FF}\\u{14647}-\\u{10FFFF}]'
 		);
 	});
 	it('should not transpile unicode property when unicodePropertyEscapes is not enabled', () => {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -421,12 +421,25 @@ describe('unicodeSets (v) flag', () => {
 				}, throws);
 			});
 		} else {
+			const transpiled = rewritePattern(pattern, flags, options);
 			it(`rewrites \`${inputRE}\` correctly ${transformUnicodeFlag ? 'without ' : ''}using the u flag`, () => {
-				const transpiled = rewritePattern(pattern, flags, options);
 				if (transpiled != '(?:' + expected + ')') {
 					assert.strictEqual(transpiled, expected);
 				}
 			});
+			if (fixture.matches) {
+				// todo: infer output flags from fixture input flags and options
+				const transpiledRegex = new RegExp(`^${transpiled}$`);
+				for (const match of fixture.matches) {
+					assert.match(match, transpiledRegex);
+				}
+			}
+			if (fixture.nonMatches) {
+				const transpiledRegex = new RegExp(`^${transpiled}$`);
+				for (const nonMatch of fixture.nonMatches) {
+					assert.doesNotMatch(nonMatch, transpiledRegex);
+				}
+			}
 		}
 	}
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -398,6 +398,26 @@ describe('character classes', () => {
 
 
 describe('unicodeSets (v) flag', () => {
+	// Re-use the unicode fixtures but replacing the input pattern's `u` flag with `v` flag
+	for (const fixture of unicodeFixtures) {
+		if (fixture.flags.includes("u")) {
+			for (let flag of fixture.flags) {
+				flag = flag.replace("u", "v");
+				const { pattern, transpiled: expected } = fixture;
+				const inputRE = `/${pattern}/${flag}`;
+				it(`rewrites \`${inputRE}\` correctly without using the u flag`, () => {
+					const transpiled = rewritePattern(pattern, flag, {
+						unicodeSetsFlag: "transform",
+						unicodeFlag: "transform",
+					});
+					if (transpiled != "(?:" + expected + ")") {
+						assert.strictEqual(transpiled, expected);
+					}
+				});
+			}
+		}
+	}
+
 	if (IS_NODE_6) return;
 
 	for (const fixture of unicodeSetFixtures) {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -35,6 +35,9 @@ function getOutputFlags(inputFlags, options) {
 	if (options.unicodeFlag === "transform") {
 		result = result.replace("u", "");
 	}
+	if (options.dotAllFlag === "transform") {
+		result = result.replace("s", "");
+	}
 	return result;
 }
 


### PR DESCRIPTION
In this PR we reuse the unicode fixtures for the v-flag tests, based the observation that `/.../u` and `/.../v` should yield the same result unless set/string properties features are involved.

We also introduce the `matches` and `nonMatches` properties to the v-flag fixture runner: They includes the strings that the transpiled regex is supposed to match / reject. It is useful when the transpiled regex is too verbose for proper comprehension.

<s>This PR includes commits from #84, I will rebase once that PR is merged.</s>

<s>This is a draft PR as I still haven't figured out how to avoid double-bmpify regex strings: In the negative set notation we extract single code points from the `UNICODE_SET`, which yields surrogate stuffs in the output, but then it was bmp-ified again in the `regenerate`, yielding longer than necessary results, though it seems correct.</s>