### PR TITLE
Fix invert astral capture regression

### DIFF
--- a/rewrite-pattern.js
+++ b/rewrite-pattern.js
@@ -526,8 +526,7 @@ const processCharacterClass = (
 					} else {
 						// Generate negative set directly when case folding is not involved.
 						const negativeSet = UNICODE_SET.clone().remove(singleChars);
-						const bmpOnly = regenerateContainsAstral(negativeSet);
-						update(characterClassItem, negativeSet.toString({ bmpOnly: bmpOnly }));
+						update(characterClassItem, negativeSet.toString(regenerateOptions));
 					}
 				} else {
 					update(characterClassItem, `(?!${setStr})[\\s\\S]`);

--- a/tests/fixtures/character-class.js
+++ b/tests/fixtures/character-class.js
@@ -46,7 +46,7 @@ const characterClassFixtures = [
 		flags: 'u',
 		matches: ["k", "\u212a", "\u{12345}", "\uDAAA", "\uDDDD"],
 		nonMatches: ["K"],
-		expected: '(?:[\\0-JL-\\uFFFF]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF])',
+		expected: '(?:[\\0-JL-\\uD7FF\\uE000-\\uFFFF]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF]|[\\uD800-\\uDBFF](?![\\uDC00-\\uDFFF])|(?:[^\\uD800-\\uDBFF]|^)[\\uDC00-\\uDFFF])',
 		options: { unicodeFlag: 'transform' }
 	},
 	{
@@ -54,7 +54,7 @@ const characterClassFixtures = [
 		flags: 'u',
 		matches: ["K", "\u212a", "\u{12345}", "\uDAAA", "\uDDDD"],
 		nonMatches: ["k"],
-		expected: '(?:[\\0-jl-\\uFFFF]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF])',
+		expected: '(?:[\\0-jl-\\uD7FF\\uE000-\\uFFFF]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF]|[\\uD800-\\uDBFF](?![\\uDC00-\\uDFFF])|(?:[^\\uD800-\\uDBFF]|^)[\\uDC00-\\uDFFF])',
 		options: { unicodeFlag: 'transform' }
 	},
 	{
@@ -62,7 +62,7 @@ const characterClassFixtures = [
 		flags: 'u',
 		matches: ["K", "k", "\u{12345}", "\uDAAA", "\uDDDD"],
 		nonMatches: ["\u212a"],
-		expected: '(?:[\\0-\\u2129\\u212B-\\uFFFF]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF])',
+		expected: '(?:[\\0-\\u2129\\u212B-\\uD7FF\\uE000-\\uFFFF]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF]|[\\uD800-\\uDBFF](?![\\uDC00-\\uDFFF])|(?:[^\\uD800-\\uDBFF]|^)[\\uDC00-\\uDFFF])',
 		options: { unicodeFlag: 'transform' }
 	},
 	{
@@ -70,7 +70,7 @@ const characterClassFixtures = [
 		flags: 'u',
 		matches: ["K", "k", "\u{12345}", "\u{1D50F}", "\uDAAA", "\uDDDD"],
 		nonMatches: ["\u{1D50E}"],
-		expected: '(?:[\\0-\\uFFFF]|[\\uD800-\\uD834\\uD836-\\uDBFF][\\uDC00-\\uDFFF]|\\uD835[\\uDC00-\\uDD0D\\uDD0F-\\uDFFF])',
+		expected: '(?:[\\0-\\uD7FF\\uE000-\\uFFFF]|[\\uD800-\\uD834\\uD836-\\uDBFF][\\uDC00-\\uDFFF]|\\uD835[\\uDC00-\\uDD0D\\uDD0F-\\uDFFF]|[\\uD800-\\uDBFF](?![\\uDC00-\\uDFFF])|(?:[^\\uD800-\\uDBFF]|^)[\\uDC00-\\uDFFF])',
 		options: { unicodeFlag: 'transform' }
 	},
 	{
@@ -96,6 +96,34 @@ const characterClassFixtures = [
 		flags: 'u',
 		expected: '[^\u{1D50E}]',
 		options: {}
+	},
+	{
+		pattern: '^[^❤️]',
+		flags: 'u',
+		options: { unicodeFlag: 'transform' },
+		expected: '^(?:[\\0-\\u2763\\u2765-\\uD7FF\\uE000-\\uFE0E\\uFE10-\\uFFFF]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF]|[\\uD800-\\uDBFF](?![\\uDC00-\\uDFFF])|(?:[^\\uD800-\\uDBFF]|^)[\\uDC00-\\uDFFF])',
+		nonMatches: ['❤️']
+	},
+	{
+		pattern: '^[^🧡]',
+		flags: 'u',
+		options: { unicodeFlag: 'transform' },
+		expected: '^(?:[\\0-\\uD7FF\\uE000-\\uFFFF]|[\\uD800-\\uD83D\\uD83F-\\uDBFF][\\uDC00-\\uDFFF]|\\uD83E[\\uDC00-\\uDDE0\\uDDE2-\\uDFFF]|[\\uD800-\\uDBFF](?![\\uDC00-\\uDFFF])|(?:[^\\uD800-\\uDBFF]|^)[\\uDC00-\\uDFFF])',
+		nonMatches: ['🧡']
+	},
+	{
+		pattern: '[^💛]',
+		flags: 'u',
+		options: { unicodeFlag: 'transform' },
+		expected: '(?:[\\0-\\uD7FF\\uE000-\\uFFFF]|[\\uD800-\\uD83C\\uD83E-\\uDBFF][\\uDC00-\\uDFFF]|\\uD83D[\\uDC00-\\uDC9A\\uDC9C-\\uDFFF]|[\\uD800-\\uDBFF](?![\\uDC00-\\uDFFF])|(?:[^\\uD800-\\uDBFF]|^)[\\uDC00-\\uDFFF])',
+		nonMatches: ['💛']
+	},
+	{
+		pattern: '[^💚]',
+		flags: 'u',
+		options: { unicodeFlag: 'transform' },
+		expected: '(?:[\\0-\\uD7FF\\uE000-\\uFFFF]|[\\uD800-\\uD83C\\uD83E-\\uDBFF][\\uDC00-\\uDFFF]|\\uD83D[\\uDC00-\\uDC99\\uDC9B-\\uDFFF]|[\\uD800-\\uDBFF](?![\\uDC00-\\uDFFF])|(?:[^\\uD800-\\uDBFF]|^)[\\uDC00-\\uDFFF])',
+		nonMatches: ['💚']
 	}
 ];
 

--- a/tests/fixtures/unicode-set.js
+++ b/tests/fixtures/unicode-set.js
@@ -107,7 +107,7 @@ const unicodeSetFixtures = [
 		pattern: '[^[a-z][f-h]]',
 		matches: ["A", "\u{12345}", "\uDAAA", "\uDDDD"],
 		nonMatches: ["a", "z"],
-		expected: '(?:[\\0-`\\{-\\uFFFF]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF])',
+		expected: '(?:[\\0-`\\{-\\uD7FF\\uE000-\\uFFFF]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF]|[\\uD800-\\uDBFF](?![\\uDC00-\\uDFFF])|(?:[^\\uD800-\\uDBFF]|^)[\\uDC00-\\uDFFF])',
 		options: TRANSFORM_U
 	},
 	{

--- a/tests/fixtures/unicode.js
+++ b/tests/fixtures/unicode.js
@@ -185,7 +185,7 @@ const unicodeFixtures = [
 		'matches': ['b', 'A', '\u{1D49C}', '\uDAAA', '\uDDDD'],
 		'nonMatches': ['a'],
 		'flags': FLAGS_WITH_UNICODE_WITHOUT_I,
-		'transpiled': '(?:[\\0-`b-\\uFFFF]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF])'
+		'transpiled': '(?:[\\0-`b-\\uD7FF\\uE000-\\uFFFF]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF]|[\\uD800-\\uDBFF](?![\\uDC00-\\uDFFF])|(?:[^\\uD800-\\uDBFF]|^)[\\uDC00-\\uDFFF])'
 	},
 	{
 		'pattern': '[^a]',

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -119,7 +119,7 @@ describe('unicodePropertyEscapes', () => {
 		);
 		assert.equal(
 			rewritePattern('[^\\p{ASCII_Hex_Digit}_]', 'u', features),
-			'(?:[\\0-\\/:-@G-\\^`g-\\uFFFF]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF])'
+			'(?:[\\0-\\/:-@G-\\^`g-\\uD7FF\\uE000-\\uFFFF]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF]|[\\uD800-\\uDBFF](?![\\uDC00-\\uDFFF])|(?:[^\\uD800-\\uDBFF]|^)[\\uDC00-\\uDFFF])'
 		);
 		assert.equal(
 			rewritePattern('[\\P{Script_Extensions=Anatolian_Hieroglyphs}]', 'u', features),
@@ -416,11 +416,11 @@ describe('character classes', () => {
 				assert.strictEqual(transpiled, expected);
 			}
 			for (const match of fixture.matches || []) {
-				const transpiledRegex = new RegExp(`^${transpiled}$`, getOutputFlags(flags, options));
+				const transpiledRegex = new RegExp(transpiled, getOutputFlags(flags, options));
 				assert.match(match, transpiledRegex);
 			}
 			for (const nonMatch of fixture.nonMatches || []) {
-				const transpiledRegex = new RegExp(`^${transpiled}$`, getOutputFlags(flags, options));
+				const transpiledRegex = new RegExp(transpiled, getOutputFlags(flags, options));
 				assert.doesNotMatch(nonMatch, transpiledRegex);
 			}
 		});
@@ -445,11 +445,11 @@ describe('unicodeSets (v) flag', () => {
 						assert.strictEqual(transpiled, expected);
 					}
 					for (const match of fixture.matches || []) {
-						const transpiledRegex = new RegExp(`^${transpiled}$`, getOutputFlags(flag, options));
+						const transpiledRegex = new RegExp(transpiled, getOutputFlags(flag, options));
 						assert.match(match, transpiledRegex);
 					}
 					for (const nonMatch of fixture.nonMatches || []) {
-						const transpiledRegex = new RegExp(`^${transpiled}$`, getOutputFlags(flag, options));
+						const transpiledRegex = new RegExp(transpiled, getOutputFlags(flag, options));
 						assert.doesNotMatch(nonMatch, transpiledRegex);
 					}
 				});
@@ -487,11 +487,11 @@ describe('unicodeSets (v) flag', () => {
 				}
 			});
 			for (const match of fixture.matches || []) {
-				const transpiledRegex = new RegExp(`^${transpiled}$`, getOutputFlags(flags, options));
+				const transpiledRegex = new RegExp(transpiled, getOutputFlags(flags, options));
 				assert.match(match, transpiledRegex);
 			}
 			for (const nonMatch of fixture.nonMatches || []) {
-				const transpiledRegex = new RegExp(`^${transpiled}$`, getOutputFlags(flags, options));
+				const transpiledRegex = new RegExp(transpiled, getOutputFlags(flags, options));
 				assert.doesNotMatch(nonMatch, transpiledRegex);
 			}
 		}


### PR DESCRIPTION
Fix Babel test262 errors from recent regressions

```
not ok 11237 test/language/literals/regexp/u-astral-char-class-invert.js default # (expected success, got runtime error)
  ---
  name: Test262Error
  message: 'Expected SameValue(«�», «null») to be true'
  stack: >
    Test262Error: Expected SameValue(«�», «null») to be true

    /home/runner/work/babel/babel/babel-test262-runner/lib/run-tests/index.js:80:17

  ...
not ok 11239 test/language/literals/regexp/u-astral-char-class-invert.js strict mode # (expected success, got runtime error)
  ---
  name: Test262Error
  message: 'Expected SameValue(«�», «null») to be true'
  stack: >
    Test262Error: Expected SameValue(«�», «null») to be true

    /home/runner/work/babel/babel/babel-test262-runner/lib/run-tests/index.js:80:17
```
Other test262 errors will be tracked in https://github.com/jviereck/regjsparser/issues/134