### PR TITLE
Bump regjsparser

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
 		"regenerate": "^1.4.2",
 		"regenerate-unicode-properties": "^10.2.0",
 		"regjsgen": "^0.8.0",
-		"regjsparser": "^0.10.0",
+		"regjsparser": "^0.11.0",
 		"unicode-match-property-ecmascript": "^2.0.0",
 		"unicode-match-property-value-ecmascript": "^2.1.0"
 	},


### PR DESCRIPTION
This PR is based on https://github.com/mathiasbynens/regexpu-core/pull/92, otherwise CI will be failing due to Unicode 16 changes in our depending packages.

This PR should unblock Babel upgrading `regexpu-core` to 6.