### PR TITLE
always enable modifiers parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,13 +140,7 @@ These options can be set to `false` or `'transform'`. When using `'transform'`, 
   // → '(?:(?![f-h])[\s\S])' (to be used without /u)
   ```
 
-#### Experimental regular expression features
-
-These options can be set to `false`, `'parse'` and `'transform'`. When using `'transform'`, the corresponding features are compiled to older syntax that can run in older browsers. When using `'parse'`, they are parsed and left as-is in the output pattern. When using `false` (the default), they result in a syntax error if used.
-
-Once these features become stable (when the proposals are accepted as part of ECMAScript), they will be parsed by default and thus `'parse'` will behave like `false`.
-
-- `modifiers` - [Inline `m`/`s`/`i` modifiers](https://github.com/tc39/proposal-regexp-modifiers)
+- `modifiers` - [Inline `i`/`m`/`s` modifiers](https://github.com/tc39/proposal-regexp-modifiers)
 
   ```js
   rewritePattern('(?i:[a-z])[a-z]', '', {
@@ -154,6 +148,12 @@ Once these features become stable (when the proposals are accepted as part of EC
   });
   // → '(?:[a-zA-Z])([a-z])'
   ```
+
+#### Experimental regular expression features
+
+These options can be set to `false`, `'parse'` and `'transform'`. When using `'transform'`, the corresponding features are compiled to older syntax that can run in older browsers. When using `'parse'`, they are parsed and left as-is in the output pattern. When using `false` (the default), they result in a syntax error if used.
+
+Once these features become stable (when the proposals are accepted as part of ECMAScript), they will be parsed by default and thus `'parse'` will behave like `false`.
 
 #### Miscellaneous options
 

--- a/rewrite-pattern.js
+++ b/rewrite-pattern.js
@@ -810,9 +810,13 @@ const validateOptions = (options) => {
 			case 'unicodePropertyEscapes':
 			case 'unicodeSetsFlag':
 			case 'namedGroups':
-			case 'modifiers':
 				if (value != null && value !== false && value !== 'transform') {
 					throw new Error(`.${key} must be false (default) or 'transform'.`);
+				}
+				break;
+			case 'modifiers':
+				if (value != null && value !== false && value !== 'parse' && value !== 'transform') {
+					throw new Error(`.${key} must be false (default), 'parse' or 'transform'.`);
 				}
 				break;
 			case 'onNamedGroup':
@@ -855,8 +859,9 @@ const rewritePattern = (pattern, flags, options) => {
 	config.modifiersData.m = undefined;
 
 	const regjsparserFeatures = {
-		// Always enable every stable RegExp feature
-		'modifiers': true,
+		'modifiers': Boolean(options && options.modifiers),
+
+		// Enable every stable RegExp feature by default
 		'unicodePropertyEscape': true,
 		'unicodeSet': true,
 		'namedGroups': true,

--- a/rewrite-pattern.js
+++ b/rewrite-pattern.js
@@ -810,13 +810,9 @@ const validateOptions = (options) => {
 			case 'unicodePropertyEscapes':
 			case 'unicodeSetsFlag':
 			case 'namedGroups':
+			case 'modifiers':
 				if (value != null && value !== false && value !== 'transform') {
 					throw new Error(`.${key} must be false (default) or 'transform'.`);
-				}
-				break;
-			case 'modifiers':
-				if (value != null && value !== false && value !== 'parse' && value !== 'transform') {
-					throw new Error(`.${key} must be false (default), 'parse' or 'transform'.`);
 				}
 				break;
 			case 'onNamedGroup':
@@ -859,9 +855,8 @@ const rewritePattern = (pattern, flags, options) => {
 	config.modifiersData.m = undefined;
 
 	const regjsparserFeatures = {
-		'modifiers': Boolean(options && options.modifiers),
-
-		// Enable every stable RegExp feature by default
+		// Always enable every stable RegExp feature
+		'modifiers': true,
 		'unicodePropertyEscape': true,
 		'unicodeSet': true,
 		'namedGroups': true,

--- a/rewrite-pattern.js
+++ b/rewrite-pattern.js
@@ -814,6 +814,7 @@ const validateOptions = (options) => {
 					throw new Error(`.${key} must be false (default) or 'transform'.`);
 				}
 				break;
+			// todo: remove modifiers: 'parse' in regexpu-core v7
 			case 'modifiers':
 				if (value != null && value !== false && value !== 'parse' && value !== 'transform') {
 					throw new Error(`.${key} must be false (default), 'parse' or 'transform'.`);
@@ -859,9 +860,8 @@ const rewritePattern = (pattern, flags, options) => {
 	config.modifiersData.m = undefined;
 
 	const regjsparserFeatures = {
-		'modifiers': Boolean(options && options.modifiers),
-
 		// Enable every stable RegExp feature by default
+		'modifiers': true,
 		'unicodePropertyEscape': true,
 		'unicodeSet': true,
 		'namedGroups': true,

--- a/tests/fixtures/modifiers.js
+++ b/tests/fixtures/modifiers.js
@@ -60,7 +60,7 @@ const modifiersFixtures = [
 	{
 		'pattern': '(?i:[\\q{ab|cd|abc}--\\q{abc}--\\q{cd}])',
 		'flags': 'v',
-		'options':  { unicodeSetsFlag: 'transform', modifiers: 'parse' },
+		'options':  { unicodeSetsFlag: 'transform', modifiers: false },
 		'expected': '(?i:(?:ab))',
 		'expectedFlags': 'u',
 	},	{
@@ -179,7 +179,7 @@ const modifiersFixtures = [
 	{
 		'pattern': '(?-i:[\\q{ab|cd|abc}--\\q{abc}--\\q{cd}])',
 		'flags': 'iv',
-		'options':  { unicodeSetsFlag: 'transform', modifiers: 'parse' },
+		'options':  { unicodeSetsFlag: 'transform', modifiers: false },
 		'expected': '(?-i:(?:ab))',
 		'expectedFlags': 'iu',
 	},	{
@@ -270,6 +270,13 @@ const modifiersFixtures = [
 		'expected': '(?:(?:^|(?<=[\\n\\r\\u2028\\u2029]))[A-Za-z])',
 		'expectedFlags': '',
 	},
+	{
+		'pattern': '(?ims:^[a-z])',
+		'flags': '',
+		'expected': '(?ims:^[a-z])',
+		'expectedFlags': '',
+		'options': { 'modifiers': false }
+	},
 	// -ims
 	{
 		'pattern': '(?-ims:^[a-z].)(^[a-z].)',
@@ -281,6 +288,12 @@ const modifiersFixtures = [
 		'pattern': '(?-ims:^[a-z].)(^[a-z].)',
 		'expected': '(?:^[a-z].)(^[a-z].)',
 		'expectedFlags': '',
+	},
+	{
+		'pattern': '(?-ims:^[a-z].)(^[a-z].)',
+		'expected': '(?-ims:^[a-z].)(^[a-z].)',
+		'expectedFlags': '',
+		'options': { 'modifiers': false }
 	},
 ].filter(Boolean);
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -547,11 +547,5 @@ describe('modifiers', () => {
 			}
 		});
 	}
-
-	it('No `modifiers:"transform"`', () => {
-		assert.throws(() => {
-			rewritePattern('(?i:a)', '');
-		});
-	})
 });
 


### PR DESCRIPTION
The modifiers proposal has reached Stage 4 in the Oct 2024 meeting. Here we silently ignored the `modifiers: "parse"` option, this feature will be always parsed.