### PR TITLE
Add d.ts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,14 +15,14 @@ jobs:
       matrix:
         # Include all major maintenance + active LTS + current Node.js versions.
         # https://github.com/nodejs/Release#release-schedule
-        node: [18, 20, 22]
+        node: [20, 22, 24]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up Node.js 22
+      - name: Set up Node.js 24
         uses: actions/setup-node@v3
         with:
-          node-version: 22
+          node-version: 24
       - name: Install dependencies
         run: npm install
       - name: Build

--- a/rewrite-pattern.d.ts
+++ b/rewrite-pattern.d.ts
@@ -1,12 +1,12 @@
 declare module "regexpu-core" {
   export type RegexpuOptions = {
     unicodeFlag?: "transform" | false;
-    unicodeSetsFlag?: "transform" | "parse" | false;
+    unicodeSetsFlag?: "transform" | false;
     dotAllFlag?: "transform" | false;
     unicodePropertyEscapes?: "transform" | false;
     namedGroups?: "transform" | false;
     onNamedGroup?: (name: string, index: number) => void;
-    modifiers?: "transform" | false;
+    modifiers?: "transform" | false | "parse";
     onNewFlags?: (flags: string) => void;
   };
   export default function rewritePattern(

--- a/rewrite-pattern.d.ts
+++ b/rewrite-pattern.d.ts
@@ -1,0 +1,17 @@
+declare module "regexpu-core" {
+  export type RegexpuOptions = {
+    unicodeFlag?: "transform" | false;
+    unicodeSetsFlag?: "transform" | "parse" | false;
+    dotAllFlag?: "transform" | false;
+    unicodePropertyEscapes?: "transform" | false;
+    namedGroups?: "transform" | false;
+    onNamedGroup?: (name: string, index: number) => void;
+    modifiers?: "transform" | false;
+    onNewFlags?: (flags: string) => void;
+  };
+  export default function rewritePattern(
+    pattern: string,
+    flags: string,
+    options: RegexpuOptions | undefined
+  ): string;
+}


### PR DESCRIPTION
In this PR we bumped CI Node.js target and added a TS declaration file. The declaration is revised from the one we have used in the Babel repo for 3 years: https://github.com/babel/babel/blob/b41f8cdd0183e800de58c573a4f57497f72b2e26/lib/regexpu-core.d.ts, I think it is time to move the declarations to the upstream as it may benefit other users.