### PR TITLE
add d.ts to published files

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
 	"files": [
 		"LICENSE-MIT.txt",
 		"rewrite-pattern.js",
+		"rewrite-pattern.d.ts",
 		"data/all-characters.js",
 		"data/character-class-escape-sets.js",
 		"data/i-bmp-mappings.js",


### PR DESCRIPTION
As a follow-up to #108, this PR adds the type definitions to the published files.

Could you do a new patch release? Thank you.